### PR TITLE
Refactor(HealthProfile): Remove growth chart preview

### DIFF
--- a/client/src/components/HealthProfilePage.js
+++ b/client/src/components/HealthProfilePage.js
@@ -95,19 +95,7 @@ const HealthProfilePage = () => {
                 <div className="grid-col-right">
                     <div className="action-card" onClick={() => history.push(`/growth-chart/${childId}`)}>
                         <h4>نمودار رشد</h4>
-                        <div className="chart-preview">
-                            <ResponsiveContainer width="100%" height="100%">
-                                <LineChart data={(child.growthData && child.growthData.length > 0) ? child.growthData : [{date: 'شروع', height: 50, weight: 3}]}>
-                                    <CartesianGrid strokeDasharray="3 3" />
-                                    <XAxis dataKey="date" />
-                                    <YAxis />
-                                    <Tooltip />
-                                    <Legend />
-                                    <Line type="monotone" dataKey="height" stroke="#8884d8" activeDot={{ r: 8 }} />
-                                    <Line type="monotone" dataKey="weight" stroke="#82ca9d" />
-                                </LineChart>
-                            </ResponsiveContainer>
-                        </div>
+                        <p>نمایش کامل نمودار</p>
                     </div>
                     <div className="actions-grid">
                         <div className="action-card" onClick={() => setIsVisitModalOpen(true)}>


### PR DESCRIPTION
I removed the growth chart preview from the health profile page. The action card now directly navigates to the full growth chart view, improving your experience by reducing an unnecessary click.