### PR TITLE
Fix(api): Return full user profile from GET /api/users/:id

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -150,7 +150,8 @@ app.get('/api/users/:id', (req, res) => {
     const user = users[req.params.id];
     if (user) {
         // Ensure we don't send the password back
-        res.json({ id: user.id, username: user.username, email: user.email });
+        const { password, ...userWithoutPassword } = user;
+        res.json(userWithoutPassword);
     } else {
         res.status(404).json({ message: 'کاربر یافت نشد' });
     }


### PR DESCRIPTION
Your profile page was not displaying saved information (First Name, Last Name, Mobile, etc.) after you navigated away from the page or refreshed it.

This was happening because the `GET /api/users/:id` endpoint in `server.js` was only returning a partial user object, containing only your `id`, `username`, and `email`. It omitted all other profile fields.

I fixed this by modifying the endpoint to return the complete user object, while still excluding the `password` field for security. This ensures that the frontend can correctly fetch and display your complete user information every time the profile page is loaded.