### PR TITLE
Hotfix(client): Rename history variable to fix compilation error

### DIFF
--- a/client/src/components/HealthProfilePage.js
+++ b/client/src/components/HealthProfilePage.js
@@ -8,7 +8,7 @@ import './HealthProfilePage.css';
 Modal.setAppElement('#root');
 
 const HealthProfilePage = () => {
-    const history = useHistory();
+    const routerHistory = useHistory();
     const { childId } = useParams();
     const [child, setChild] = useState(null);
     const [visits, setVisits] = useState([]);
@@ -29,8 +29,8 @@ const HealthProfilePage = () => {
             const docsRes = await fetch(`http://localhost:5000/api/documents/${childId}`);
             const docsData = await docsRes.json();
             setDocuments(docsData);
-        } catch (error) { history.push('/my-children'); }
-    }, [childId]);
+        } catch (error) { routerHistory.push('/my-children'); }
+    }, [childId, routerHistory]);
 
     useEffect(() => { fetchAllData(); }, [fetchAllData]);
 
@@ -52,7 +52,7 @@ const HealthProfilePage = () => {
     return (
         <div className="health-profile-page">
             <nav className="page-nav-final">
-                <button onClick={() => history.push('/my-children')} className="back-btn">
+                <button onClick={() => routerHistory.push('/my-children')} className="back-btn">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
                     <span>لیست کودکان</span>
                 </button>
@@ -89,7 +89,7 @@ const HealthProfilePage = () => {
                             </div>
                             <p>{child.special_illnesses && child.special_illnesses.description}</p>
                         </div>
-                        <button onClick={() => history.push(`/health-analysis/${child.id}`)} className="edit-main-info-btn">مشاهده تحلیل پرونده</button>
+                        <button onClick={() => routerHistory.push(`/health-analysis/${child.id}`)} className="edit-main-info-btn">مشاهده تحلیل پرونده</button>
                     </div>
                 </div>
                 <div className="grid-col-right">
@@ -108,7 +108,7 @@ const HealthProfilePage = () => {
                                 </LineChart>
                             </ResponsiveContainer>
                         </div>
-                        <button onClick={() => history.push(`/growth-chart/${childId}`)} className="view-full-chart-btn">نمایش کامل نمودار</button>
+                        <button onClick={() => routerHistory.push(`/growth-chart/${childId}`)} className="view-full-chart-btn">نمایش کامل نمودار</button>
                     </div>
                     <div className="actions-grid">
                         <div className="action-card" onClick={() => setIsVisitModalOpen(true)}>


### PR DESCRIPTION
This is a hotfix for a persistent compilation error in `HealthProfilePage.js` that was causing the entire application to fail to compile, leading to an unresponsive UI.

The ESLint rule `no-restricted-globals` was being triggered by the variable name `history`, likely due to an overly sensitive configuration that flagged it as a global variable despite it being correctly scoped by the `useHistory` hook.

This commit resolves the issue by renaming all instances of the `history` variable to `routerHistory` within the component. This avoids the name collision with the `window.history` global, satisfies the linter, and allows the application to compile successfully.