### PR TITLE
fix: Remove unused variable in ServiceTiles

### DIFF
--- a/client/src/components/ServiceTiles.js
+++ b/client/src/components/ServiceTiles.js
@@ -24,7 +24,6 @@ const ServiceTiles = () => {
     const [selectedService, setSelectedService] = useState('');
 
     const handleServiceClick = async (serviceId) => {
-        const serviceUrl = serviceId.replace('-', '/'); // e.g., 'growth-chart' -> 'growth/chart' - adjust if needed
         try {
             const response = await fetch('http://localhost:5000/api/children');
             const data = await response.json();


### PR DESCRIPTION
This commit removes an unused and potentially confusing variable from the `handleServiceClick` function in the `ServiceTiles` component. This is suspected to be the cause of the tile click not working as expected.