### PR TITLE
refactor: Use Link component for clickable service tiles

### DIFF
--- a/client/src/components/ServiceTiles.js
+++ b/client/src/components/ServiceTiles.js
@@ -56,12 +56,15 @@ const ServiceTiles = () => {
                     const requiresChild = service.id === 'growth-chart' || service.id === 'vaccination';
                     if (requiresChild) {
                         return (
-                            <div key={service.id} className="tile-link" onClick={() => handleServiceClick(service.id)}>
+                            <Link to="#" key={service.id} className="tile-link" onClick={(e) => {
+                                e.preventDefault();
+                                handleServiceClick(service.id);
+                            }}>
                                 <div className="tile">
                                     <div className="tile-icon">{service.icon}</div>
                                     <div className="tile-name">{service.name}</div>
                                 </div>
-                            </div>
+                            </Link>
                         );
                     }
                     return (


### PR DESCRIPTION
This commit refactors the ServiceTiles component to use the react-router-dom `Link` component for tiles that require a child selection, instead of a `div` with an `onClick` handler.

This change is intended to fix a bug where the vaccination tile was unresponsive. Using the `Link` component makes the implementation more robust and consistent with the other service tiles.