### PR TITLE
fix: Add missing FontAwesome dependencies to package.json

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.1.1",
+    "@fortawesome/free-solid-svg-icons": "^6.1.1",
+    "@fortawesome/react-fontawesome": "^0.1.18",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "5.2.0",


### PR DESCRIPTION
This commit manually adds the dependencies for `@fortawesome/fontawesome-svg-core`, `@fortawesome/free-solid-svg-icons`, and `@fortawesome/react-fontawesome` to the `client/package.json` file.

This is necessary to resolve a `Module not found` compilation error that occurs when the required packages for the icons on the VaccinationPage are not installed. This change will allow you to run `npm install` and have the correct dependencies available.