### PR TITLE
fix: Correct syntax error in EditChildPage

### DIFF
--- a/client/src/components/EditChildPage.js
+++ b/client/src/components/EditChildPage.js
@@ -46,38 +46,6 @@ const EditChildPage = () => {
         };
         fetchChildData();
     }, [id, history]);
-        lastName: '',
-        nationalId: '',
-        gender: 'boy',
-        fatherName: '',
-        // Birth Info
-        birthWeight: '',
-        birthHeight: '',
-        birthHeadCircumference: '',
-        birthType: 'natural',
-        gestationalAge: '',
-        birthPlace: '',
-        apgar1: '',
-        apgar5: '',
-        // Other Info from previous form
-        height: '',
-        weight: '',
-        bloodType: 'A+',
-        allergies: {
-            types: { 'غذایی': false, 'دارویی': false, 'محیطی': false, 'سایر': false },
-            description: ''
-        },
-        special_illnesses: {
-            types: { 'مزمن': false, 'ژنتیکی': false, 'تکاملی': false, 'سایر': false },
-            description: ''
-        }
-    });
-    const [birthDate, setBirthDate] = useState(new Date());
-    const [avatarFile, setAvatarFile] = useState(null);
-    const [preview, setPreview] = useState(null);
-    const [isSubmitting, setIsSubmitting] = useState(false);
-    const [openSection, setOpenSection] = useState('identity');
-    const [documentFiles, setDocumentFiles] = useState([]);
 
     const handleSectionToggle = (section) => {
         setOpenSection(openSection === section ? null : section);


### PR DESCRIPTION
This commit removes a large block of stray code that was erroneously left in the `EditChildPage.js` component during a refactoring process. This code block included duplicate state declarations and was placed incorrectly in the component body, causing a critical syntax error and preventing the application from compiling.

The removal of this code resolves the compilation failure.