### PR TITLE
fix: Correct compilation errors in EditChildPage

### DIFF
--- a/client/src/components/EditChildPage.js
+++ b/client/src/components/EditChildPage.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import DatePicker from "react-datepicker";
 import { format } from 'date-fns';
@@ -334,4 +334,4 @@ const EditChildPage = () => {
     );
 };
 
-export default AddChildPage;
+export default EditChildPage;


### PR DESCRIPTION
This commit fixes two critical errors in `EditChildPage.js` that prevented the application from compiling:
1.  Imports the `useEffect` hook from React, which was missing.
2.  Corrects the component's export statement from `export default AddChildPage` to `export default EditChildPage`.

These changes resolve the 'is not defined' errors and allow the component to be rendered correctly.