### PR TITLE
fix: Correct CSS syntax in MyChildrenPage

### DIFF
--- a/client/src/components/MyChildrenPage.css
+++ b/client/src/components/MyChildrenPage.css
@@ -1,4 +1,4 @@
-children-page-final { background-color: #f8f9fa; min-height: 100vh; }
+.children-page-final { background-color: #f8f9fa; min-height: 100vh; }
 .page-nav-final { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; padding: 0.8rem 1.5rem; background-color: #fff; box-shadow: 0 2px 4px rgba(0,0,0,0.05); }
 .page-nav-final h1 { grid-column: 2; text-align: center; margin: 0; font-size: 1.4rem; color: #343a40; }
 .nav-placeholder { grid-column: 3; }


### PR DESCRIPTION
This commit fixes a CSS syntax error in `MyChildrenPage.css`. A class selector was missing its leading dot (`.`), which likely caused the browser to ignore subsequent style rules in the file.

By correcting `.children-page-final`, the existing grid layout for the navigation bar will now be applied correctly, centering the `h1` title as intended.