### PR TITLE
feat: Center title and display calculated age on My Children page

### DIFF
--- a/client/src/components/MyChildrenPage.css
+++ b/client/src/components/MyChildrenPage.css
@@ -1,11 +1,11 @@
 .children-page-final { background-color: #f8f9fa; min-height: 100vh; }
-.page-nav-final { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; padding: 0.8rem 1.5rem; background-color: #fff; box-shadow: 0 2px 4px rgba(0,0,0,0.05); }
-.page-nav-final h1 { grid-column: 2; text-align: center; margin: 0; font-size: 1.4rem; color: #343a40; }
-.nav-placeholder { grid-column: 3; }
+.page-nav-final { display: flex; justify-content: space-between; align-items: center; padding: 0.8rem 1.5rem; background-color: #fff; box-shadow: 0 2px 4px rgba(0,0,0,0.05); }
+.page-nav-final h1 { flex-grow: 1; text-align: center; margin: 0; font-size: 1.4rem; color: #343a40; }
+.nav-placeholder { flex-basis: 120px; /* Match width of the button */ }
 
 .home-btn-final {
-    grid-column: 1;
-    justify-self: start;
+    flex-basis: 120px; /* Give it a base width */
+    justify-content: flex-start;
     background: none;
     border: none;
     cursor: pointer;

--- a/client/src/components/MyChildrenPage.js
+++ b/client/src/components/MyChildrenPage.js
@@ -29,6 +29,22 @@ const MyChildrenPage = () => {
 
     const ArrowRightIcon = () => (<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="5" y1="12" x2="19" y2="12"></line><polyline points="12 5 19 12 12 19"></polyline></svg>);
 
+    const calculateAge = (birthDateStr) => {
+        if (!birthDateStr) return 'نامشخص';
+        const birthDate = new Date(birthDateStr.replace(/\//g, '-'));
+        const today = new Date();
+        let years = today.getFullYear() - birthDate.getFullYear();
+        let months = today.getMonth() - birthDate.getMonth();
+        if (months < 0 || (months === 0 && today.getDate() < birthDate.getDate())) {
+            years--;
+            months += 12;
+        }
+        if (years === 0 && months === 0) return 'نوزاد';
+        if (years === 0) return `${months} ماهه`;
+        if (months === 0) return `${years} ساله`;
+        return `${years} سال و ${months} ماه`;
+    };
+
     return (
         <div className="children-page-final">
             <nav className="page-nav-final">
@@ -49,8 +65,8 @@ const MyChildrenPage = () => {
                             <div key={child.id} className="child-card-final">
                                 <img src={avatarUrl} alt={child.name} className="child-avatar-final" />
                                 <div className="child-info-final">
-                                    <h3>{child.name}</h3>
-                                    <p>سن: {child.age}</p>
+                                    <h3>{child.name || `${child.firstName} ${child.lastName}`}</h3>
+                                    <p>سن: {calculateAge(child.birthDate)}</p>
                                 </div>
                                 <div className="child-card-actions">
                                     <button onClick={() => history.push(`/health-profile/${child.id}`)} className="view-profile-btn-final">مشاهده پرونده</button>


### PR DESCRIPTION
This commit implements two UI/UX improvements for the `MyChildrenPage` component based on your feedback.

1.  **Center Title:** The navigation bar CSS has been refactored to use a robust `flexbox` layout, ensuring the page title is always correctly centered.
2.  **Display Age:** A new helper function, `calculateAge`, has been added to compute a child's age in years and months from their birth date. This calculated age is now displayed for each child in the list, providing more useful information to you.