### PR TITLE
fix: Ensure growth data is loaded in chart page

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -84,7 +84,19 @@ app.post('/api/children', (req, res) => {
 });
 
 app.get('/api/children', (req, res) => res.json(children));
-app.get('/api/children/:id', (req, res) => { const child = children.find(c => c.id === parseInt(req.params.id)); if (child) res.json(child); else res.status(404).json({ message: 'Not found' }); });
+app.get('/api/children/:id', (req, res) => {
+    const childId = parseInt(req.params.id);
+    const child = children.find(c => c.id === childId);
+    if (child) {
+        const childWithGrowthData = {
+            ...child,
+            growthData: growthData[childId] || []
+        };
+        res.json(childWithGrowthData);
+    } else {
+        res.status(404).json({ message: 'Not found' });
+    }
+});
 
 app.put('/api/children/:id', (req, res) => {
     const childIndex = children.findIndex(c => c.id === parseInt(req.params.id));


### PR DESCRIPTION
The `GrowthChartPage` was not displaying the full history of growth data because the `/api/children/:id` endpoint did not include it in the response.

This commit modifies the endpoint to include the `growthData` for the requested child, ensuring the chart is always accurate and up-to-date.