### PR TITLE
fix: Correct percentile calculation for extreme values

### DIFF
--- a/client/src/utils/growth-analyzer.js
+++ b/client/src/utils/growth-analyzer.js
@@ -15,8 +15,8 @@ const getPercentileForValue = (value, ageInMonths, gender, metric) => {
         return { P3: p1.P3 + factor * (p2.P3 - p1.P3), P50: p1.P50 + factor * (p2.P50 - p1.P50), P97: p1.P97 + factor * (p2.P97 - p1.P97) };
     };
     const standard = interpolate(lowerBound, upperBound);
-    if (value < standard.P3) return 3;
-    if (value > standard.P97) return 97;
+    if (value < standard.P3) return 2; // Return a value < 3
+    if (value > standard.P97) return 98; // Return a value > 97
     if (value < standard.P50) return 3 + 47 * ((value - standard.P3) / (standard.P50 - standard.P3));
     return 50 + 47 * ((value - standard.P50) / (standard.P97 - standard.P50));
 };


### PR DESCRIPTION
The growth analysis was misclassifying values above P97 or below P3 as 'Normal'. This was caused by the percentile calculation function capping the return values at 97 and 3.

This commit adjusts the return values for these cases to ensure they are categorized correctly, making the analysis consistent with the graph.