### PR TITLE
fix: Add missing closing div tag in LabTestsPage

### DIFF
--- a/client/src/components/LabTestsPage.js
+++ b/client/src/components/LabTestsPage.js
@@ -154,6 +154,7 @@ const LabTestsPage = () => {
                         })}
                     </ul>
                 )}
+                </div>
             </main>
 
             <Modal isOpen={isModalOpen} onRequestClose={() => setIsModalOpen(false)} className="add-data-modal" overlayClassName="modal-overlay">


### PR DESCRIPTION
Corrected a JSX syntax error by adding a missing `</div>` tag. This resolves a compilation failure.