### PR TITLE
feat: Make automatic reminders clickable

### DIFF
--- a/client/src/components/Reminders.css
+++ b/client/src/components/Reminders.css
@@ -114,3 +114,9 @@
     text-align: center;
     color: #666;
 }
+
+.reminder-link {
+    text-decoration: none;
+    color: inherit;
+    display: block;
+}

--- a/client/src/components/Reminders.js
+++ b/client/src/components/Reminders.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import { Link } from 'react-router-dom'; // Import Link
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBell, faTimes, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
 import AddReminderModal from './AddReminderModal'; // Import the modal
@@ -80,19 +81,30 @@ const Reminders = () => {
                         <p className="no-reminders">هیچ یادآور جدیدی وجود ندارد.</p>
                     ) : (
                         <ul className="reminders-list">
-                            {reminders.map(r => (
-                                <li key={r.id} className={`reminder-item type-${r.type}`}>
-                                    <div className="reminder-content">
-                                        <strong>{r.title}</strong>
-                                        <p>{r.message}</p>
-                                    </div>
-                                    {r.source === 'manual' && (
-                                        <button className="dismiss-btn" onClick={() => handleDismiss(r)}>
-                                            <FontAwesomeIcon icon={faTimes} />
-                                        </button>
-                                    )}
-                                </li>
-                            ))}
+                            {reminders.map(r => {
+                                const reminderContent = (
+                                    <li key={r.id} className={`reminder-item type-${r.type}`}>
+                                        <div className="reminder-content">
+                                            <strong>{r.title}</strong>
+                                            <p>{r.message}</p>
+                                        </div>
+                                        {r.source === 'manual' && (
+                                            <button className="dismiss-btn" onClick={(e) => {
+                                                e.preventDefault();
+                                                e.stopPropagation();
+                                                handleDismiss(r);
+                                            }}>
+                                                <FontAwesomeIcon icon={faTimes} />
+                                            </button>
+                                        )}
+                                    </li>
+                                );
+
+                                if (r.link) {
+                                    return <Link to={r.link} key={r.id} className="reminder-link">{reminderContent}</Link>;
+                                }
+                                return reminderContent;
+                            })}
                         </ul>
                     )}
                 </div>

--- a/server/server.js
+++ b/server/server.js
@@ -272,7 +272,8 @@ app.get('/api/reminders/all/:childId', (req, res) => {
             type: type,
             title: `واکسن: ${vaccine.name} (دوز ${vaccine.dose})`,
             message: `وضعیت: ${status}`,
-            source: 'auto'
+            source: 'auto',
+            link: `/vaccination/${child.id}` // Add link for vaccine reminders
         });
     });
 
@@ -290,7 +291,8 @@ app.get('/api/reminders/all/:childId', (req, res) => {
                         type: 'info',
                         title: 'توصیه چکاپ',
                         message: rec,
-                        source: 'auto'
+                        source: 'auto',
+                        link: `/lab-tests/${child.id}` // Add link for checkup reminders
                     });
                 }
             });


### PR DESCRIPTION
This commit enhances the new Reminders feature by making the automatically generated reminders (for vaccines and checkups) clickable.

- **Backend:** The `/api/reminders/all/:childId` endpoint now includes a `link` property in the JSON response for each automatic reminder, pointing to the relevant page (e.g., `/vaccination/:childId`).
- **Frontend:** The `Reminders.js` component now uses the `<Link>` component from `react-router-dom` to wrap these reminder items, allowing users to navigate directly to the appropriate page to take action.