### PR TITLE
fix: Fix reminder logic and dropdown closing behavior

### DIFF
--- a/client/src/components/Reminders.js
+++ b/client/src/components/Reminders.js
@@ -1,15 +1,16 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom'; // Import Link
+import React, { useState, useEffect, useCallback, useRef } from 'react'; // Import useRef
+import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBell, faTimes, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
-import AddReminderModal from './AddReminderModal'; // Import the modal
+import AddReminderModal from './AddReminderModal';
 import './Reminders.css';
 
 const Reminders = () => {
     const [reminders, setReminders] = useState([]);
     const [isOpen, setIsOpen] = useState(false);
-    const [isModalOpen, setIsModalOpen] = useState(false); // State for the modal
+    const [isModalOpen, setIsModalOpen] = useState(false);
     const [activeChildId, setActiveChildId] = useState(null);
+    const dropdownRef = useRef(null); // Create a ref for the dropdown
 
     const fetchReminders = useCallback(async (childId) => {
         if (!childId) return;
@@ -47,6 +48,25 @@ const Reminders = () => {
         return () => clearInterval(interval);
     }, [fetchAndSetChild]);
 
+    // Effect for handling clicks outside the dropdown
+    useEffect(() => {
+        const handleClickOutside = (event) => {
+            if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+                setIsOpen(false);
+            }
+        };
+
+        // Add event listener when the dropdown is open
+        if (isOpen) {
+            document.addEventListener('mousedown', handleClickOutside);
+        }
+
+        // Clean up the event listener
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+        };
+    }, [isOpen]); // Only re-run if isOpen changes
+
     const handleDismiss = async (reminder) => {
         if (!activeChildId || reminder.source !== 'manual') return; // Only dismiss manual reminders
         try {
@@ -64,7 +84,7 @@ const Reminders = () => {
     };
 
     return (
-        <div className="reminders-widget">
+        <div className="reminders-widget" ref={dropdownRef}>
             <button className="reminders-bell" onClick={() => setIsOpen(!isOpen)}>
                 <FontAwesomeIcon icon={faBell} />
                 {reminders.length > 0 && <span className="reminder-count">{reminders.length}</span>}

--- a/server/server.js
+++ b/server/server.js
@@ -251,18 +251,15 @@ app.get('/api/reminders/all/:childId', (req, res) => {
 
         if (isDone) return; // Skip completed vaccines
 
-        let status = 'upcoming';
-        let type = 'info';
+        let status = '';
+        let type = '';
 
-        if (ageInMonths > vaccine.month + 2) { // 2 months grace period
-            status = `Overdue by ${Math.floor(ageInMonths - vaccine.month)} months`;
+        if (ageInMonths > vaccine.month) {
+            status = `این واکسن دیر شده است (موعد: ${vaccine.month} ماهگی)`;
             type = 'danger';
-        } else if (ageInMonths >= vaccine.month) {
-            status = 'Due now';
-            type = 'warning';
         } else if (ageInMonths >= vaccine.month - 1) {
-            status = 'Upcoming in the next month';
-            type = 'info';
+            status = `موعد این واکسن نزدیک است (در ${vaccine.month} ماهگی)`;
+            type = 'warning';
         } else {
             return; // Skip future vaccines that are not yet upcoming
         }
@@ -271,9 +268,9 @@ app.get('/api/reminders/all/:childId', (req, res) => {
             id: `vaccine-${child.id}-${key}`,
             type: type,
             title: `واکسن: ${vaccine.name} (دوز ${vaccine.dose})`,
-            message: `وضعیت: ${status}`,
+            message: status,
             source: 'auto',
-            link: `/vaccination/${child.id}` // Add link for vaccine reminders
+            link: `/vaccination/${child.id}`
         });
     });
 


### PR DESCRIPTION
This commit addresses two bugs reported by the user in the new Reminders feature:

1.  **Backend: Corrected Reminder Logic:**
    - The logic in the `/api/reminders/all/:childId` endpoint for determining overdue vaccines has been fixed.
    - The previous logic had a grace period that was too long, causing genuinely overdue vaccines not to appear. The new, simpler logic correctly flags any vaccine as overdue if the child's age has passed the scheduled month.

2.  **Frontend: Implemented Dropdown Click-Outside:**
    - The `Reminders.js` component has been updated to include a "click-outside" handler.
    - This ensures that the reminders dropdown menu now closes automatically when the user clicks anywhere else on the page, improving the user experience.