### PR TITLE
fix: Ensure vaccinationRecords property exists on all children

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -29,7 +29,10 @@ const loadData = () => {
         const rawData = fs.readFileSync(dbPath);
         const data = JSON.parse(rawData);
         users = data.users;
-        children = data.children;
+        children = data.children.map(child => ({
+            ...child,
+            vaccinationRecords: child.vaccinationRecords || {} // Ensure property exists
+        }));
         growthData = data.growthData;
         medicalVisits = data.medicalVisits;
         medicalDocuments = data.medicalDocuments;


### PR DESCRIPTION
This commit fixes a persistent bug where overdue vaccine reminders were not being generated for older child data.

The root cause was that child objects created before a certain point were missing the `vaccinationRecords` property, causing the reminder generation logic to fail silently.

This fix modifies the `loadData` function in `server.js` to iterate through all children upon loading the database and ensures that every child object has at least an empty `{}` for the `vaccinationRecords` property. This makes the data structure consistent and the rest of the application more robust.