### PR TITLE
fix: Ensure correct date parsing for reminder logic

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -244,7 +244,7 @@ app.get('/api/reminders/all/:childId', (req, res) => {
     if (!child) return res.status(404).json({ message: 'Child not found' });
 
     const allReminders = [];
-    const ageInMonths = (new Date() - new Date(child.birthDate)) / (1000 * 60 * 60 * 24 * 30.4375);
+    const ageInMonths = (new Date() - new Date(child.birthDate.replace(/\//g, '-'))) / (1000 * 60 * 60 * 24 * 30.4375);
     const records = child.vaccinationRecords || {};
 
     // 1. Generate Vaccine Reminders


### PR DESCRIPTION
This commit fixes a persistent bug where overdue vaccine reminders were not being generated correctly.

The root cause was identified as a date parsing issue in `server.js`. The `new Date()` constructor in JavaScript can be unreliable when parsing dates with slashes (e.g., `YYYY/MM/DD`). This was causing the child's age in months to be calculated as `NaN`, which broke all subsequent comparison logic for determining if a vaccine was overdue.

The fix involves replacing the slashes in the `birthDate` string with dashes before passing it to the `new Date()` constructor (e.g., `new Date(child.birthDate.replace(/\//g, '-'))`). This ensures the date is parsed consistently and reliably, allowing the age calculation and reminder logic to function as intended.