### PR TITLE
fix: Add missing Redirect import in AdminPage

### DIFF
--- a/client/src/components/AdminPage.js
+++ b/client/src/components/AdminPage.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { NavLink, Switch, Route, useRouteMatch } from 'react-router-dom';
+import { NavLink, Switch, Route, useRouteMatch, Redirect } from 'react-router-dom';
 import './AdminPage.css';
 import AdminDashboard from './admin/AdminDashboard';
 import UserManagement from './admin/UserManagement';


### PR DESCRIPTION
This commit fixes a compilation error in the `AdminPage` component. The `Redirect` component from `react-router-dom` was being used without being imported, causing a "Redirect is not defined" error.

The `Redirect` component has been added to the import statement in `client/src/components/AdminPage.js`.