### PR TITLE
feat: Implement banner, news, and user-children view

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -13,6 +13,8 @@ import HealthAnalysisPage from './components/HealthAnalysisPage';
 import LabTestsPage from './components/LabTestsPage';
 import ProfilePage from './components/ProfilePage';
 import VaccinationPage from './components/VaccinationPage';
+import NewsPage from './components/NewsPage';
+import ArticleDetailPage from './components/ArticleDetailPage';
 import './App.css';
 
 const App = () => {
@@ -32,6 +34,8 @@ const App = () => {
                 <Route path="/lab-tests/:childId" component={LabTestsPage} />
                 <Route path="/vaccination/:childId" component={VaccinationPage} />
                 <Route path="/profile" component={ProfilePage} />
+                <Route exact path="/news" component={NewsPage} />
+                <Route path="/news/:id" component={ArticleDetailPage} />
                 <AdminRoute path="/admin" component={AdminPage} />
 
                 <Route path="/">

--- a/client/src/components/AdminPage.js
+++ b/client/src/components/AdminPage.js
@@ -3,6 +3,7 @@ import { NavLink, Switch, Route, useRouteMatch, Redirect } from 'react-router-do
 import './AdminPage.css';
 import AdminDashboard from './admin/AdminDashboard';
 import UserManagement from './admin/UserManagement';
+import UserDetailPage from './admin/UserDetailPage';
 import BannerManagement from './admin/BannerManagement';
 import ArticleManagement from './admin/ArticleManagement';
 import TicketManagement from './admin/TicketManagement';
@@ -31,7 +32,8 @@ const AdminPage = () => {
                         <Redirect to={`${path}/dashboard`} />
                     </Route>
                     <Route path={`${path}/dashboard`} component={AdminDashboard} />
-                    <Route path={`${path}/users`} component={UserManagement} />
+                    <Route exact path={`${path}/users`} component={UserManagement} />
+                    <Route path={`${path}/users/:userId`} component={UserDetailPage} />
                     <Route path={`${path}/banners`} component={BannerManagement} />
                     <Route path={`${path}/articles`} component={ArticleManagement} />
                     <Route path={`${path}/tickets`} component={TicketManagement} />

--- a/client/src/components/ArticleDetailPage.css
+++ b/client/src/components/ArticleDetailPage.css
@@ -1,0 +1,41 @@
+.article-detail-container {
+    max-width: 800px;
+    margin: 2rem auto;
+    padding: 2rem;
+    background-color: #fff;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    direction: rtl;
+}
+
+.article-detail-header {
+    text-align: right;
+    margin-bottom: 2rem;
+    border-bottom: 1px solid #eee;
+    padding-bottom: 1rem;
+}
+
+.article-detail-header h1 {
+    font-size: 2.2rem;
+    margin: 0;
+}
+
+.article-meta {
+    color: #777;
+    font-size: 0.9rem;
+    margin-top: 0.5rem;
+}
+
+.article-detail-image {
+    width: 100%;
+    max-height: 400px;
+    object-fit: cover;
+    border-radius: 8px;
+    margin-bottom: 2rem;
+}
+
+.article-detail-content {
+    font-size: 1.1rem;
+    line-height: 1.8;
+    text-align: right;
+    color: #333;
+}

--- a/client/src/components/ArticleDetailPage.js
+++ b/client/src/components/ArticleDetailPage.js
@@ -1,0 +1,60 @@
+import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import Navbar from './Navbar';
+import Footer from './Footer';
+import './ArticleDetailPage.css';
+
+const ArticleDetailPage = () => {
+    const { id } = useParams();
+    const [article, setArticle] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState('');
+
+    useEffect(() => {
+        const fetchArticle = async () => {
+            try {
+                const response = await fetch(`http://localhost:5000/api/news/${id}`);
+                if (!response.ok) throw new Error('Failed to fetch article');
+                const data = await response.json();
+                setArticle(data);
+            } catch (err) {
+                setError(err.message);
+            } finally {
+                setLoading(false);
+            }
+        };
+        fetchArticle();
+    }, [id]);
+
+    if (loading) return <p>در حال بارگذاری مقاله...</p>;
+    if (error) return <p>خطا: {error}</p>;
+    if (!article) return <p>مقاله یافت نشد.</p>;
+
+    return (
+        <div>
+            <Navbar />
+            <main className="article-detail-container">
+                <header className="article-detail-header">
+                    <h1>{article.title}</h1>
+                    <p className="article-meta">
+                        منتشر شده در: {new Date(article.createdAt).toLocaleDateString('fa-IR')}
+                    </p>
+                </header>
+                {article.imageUrl && (
+                    <img
+                        src={`http://localhost:5000${article.imageUrl}`}
+                        alt={article.title}
+                        className="article-detail-image"
+                    />
+                )}
+                <div
+                    className="article-detail-content"
+                    dangerouslySetInnerHTML={{ __html: article.content.replace(/\n/g, '<br />') }}
+                />
+            </main>
+            <Footer />
+        </div>
+    );
+};
+
+export default ArticleDetailPage;

--- a/client/src/components/Carousel.js
+++ b/client/src/components/Carousel.js
@@ -1,43 +1,49 @@
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import './Carousel.css';
 
-const slides = [
+const defaultSlides = [
     {
         image: 'https://images.unsplash.com/photo-1506748686214-e9df14d4d9d0?ixlib=rb-1.2.1&auto=format&fit=crop&w=1200&q=80',
         title: 'به سامانه رشد خوش آمدید',
-        subtitle: 'محلی برای پایش و مراقبت از سلامت فرزندان شما'
+        subtitle: 'محلی برای پایش و مراقبت از سلامت فرزندان شما',
+        link: '/about'
     },
     {
         image: 'https://images.unsplash.com/photo-1501785888041-af3ef285b470?ixlib=rb-1.2.1&auto=format&fit=crop&w=1200&q=80',
         title: 'نمودارهای رشد استاندارد',
-        subtitle: 'بر اساس آخرین داده‌های سازمان بهداشت جهانی'
-    },
-    {
-        image: 'https://images.unsplash.com/photo-1505144808419-1957a94ca61e?ixlib=rb-1.2.1&auto=format&fit=crop&w=1200&q=80',
-        title: 'یادآور واکسیناسیون',
-        subtitle: 'دیگر هیچ واکسنی را فراموش نخواهید کرد'
+        subtitle: 'بر اساس آخرین داده‌های سازمان بهداشت جهانی',
+        link: '/my-children'
     }
 ];
 
-const Carousel = () => {
+const Carousel = ({ slides = defaultSlides }) => {
     const [currentIndex, setCurrentIndex] = useState(0);
+
     useEffect(() => {
+        if (slides.length === 0) return;
         const interval = setInterval(() => {
             setCurrentIndex(prev => (prev + 1) % slides.length);
         }, 5000);
         return () => clearInterval(interval);
-    }, []);
+    }, [slides.length]);
+
+    if (slides.length === 0) {
+        return null; // Don't render anything if there are no slides
+    }
 
     return (
         <div className="carousel">
             <div className="carousel-inner" style={{ transform: `translateX(-${currentIndex * 100}%)` }}>
                 {slides.map((slide, i) => (
                     <div className="carousel-item" key={i}>
-                        <img src={slide.image} alt={slide.title} />
-                        <div className="carousel-caption">
-                            <h2>{slide.title}</h2>
-                            <p>{slide.subtitle}</p>
-                        </div>
+                        <Link to={slide.link || '#'}>
+                            <img src={slide.image} alt={slide.title} />
+                            <div className="carousel-caption">
+                                <h2>{slide.title}</h2>
+                                {slide.subtitle && <p>{slide.subtitle}</p>}
+                            </div>
+                        </Link>
                     </div>
                 ))}
             </div>

--- a/client/src/components/DashboardPage.js
+++ b/client/src/components/DashboardPage.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import Navbar from './Navbar';
 import Footer from './Footer';
 import Carousel from './Carousel';
@@ -16,12 +16,34 @@ const mockArticles = Array.from({ length: 8 }, (_, i) => ({
 }));
 
 const DashboardPage = () => {
+    const [banners, setBanners] = useState([]);
+
+    useEffect(() => {
+        const fetchBanners = async () => {
+            try {
+                const response = await fetch('http://localhost:5000/api/banners');
+                if (response.ok) {
+                    const data = await response.json();
+                    // Transform the banner data to the format expected by Carousel
+                    const formattedBanners = data.map(banner => ({
+                        image: `http://localhost:5000${banner.imageUrl}`,
+                        title: banner.title,
+                        link: banner.link
+                    }));
+                    setBanners(formattedBanners);
+                }
+            } catch (error) {
+                console.error("Failed to fetch banners:", error);
+            }
+        };
+        fetchBanners();
+    }, []);
 
     return (
         <div>
             <Navbar />
             <main>
-                <Carousel />
+                <Carousel slides={banners} />
                 <ServiceTiles />
 
                 <ContentRow title="ویدیوهای آموزشی و تربیتی" items={mockVideos} />

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -37,6 +37,7 @@ const Navbar = () => {
             </div>
             <div className="navbar-links">
                 <Link to="/dashboard">خانه</Link>
+                <Link to="/news">اخبار و مقالات</Link>
                 <Link to="/about">درباره ما</Link>
                 <Link to="/contact">تماس با ما</Link>
                 <Link to="/support">پشتیبانی</Link>

--- a/client/src/components/NewsPage.css
+++ b/client/src/components/NewsPage.css
@@ -1,0 +1,69 @@
+.news-page-container {
+    padding: 2rem;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.news-page-header {
+    text-align: center;
+    margin-bottom: 3rem;
+    direction: rtl;
+}
+
+.news-page-header h1 {
+    font-size: 2.5rem;
+    color: #2c3e50;
+}
+
+.news-page-header p {
+    font-size: 1.1rem;
+    color: #7f8c8d;
+}
+
+.articles-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 2rem;
+    direction: rtl;
+}
+
+.article-card {
+    background-color: #fff;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+    text-decoration: none;
+    color: inherit;
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.article-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 8px 16px rgba(0,0,0,0.15);
+}
+
+.article-card img {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+}
+
+.article-card-content {
+    padding: 1.5rem;
+}
+
+.article-card-content h3 {
+    margin: 0 0 0.75rem 0;
+    font-size: 1.25rem;
+}
+
+.article-card-content p {
+    margin: 0 0 1rem 0;
+    color: #555;
+    font-size: 0.95rem;
+}
+
+.read-more {
+    font-weight: bold;
+    color: #3498db;
+}

--- a/client/src/components/NewsPage.js
+++ b/client/src/components/NewsPage.js
@@ -1,0 +1,56 @@
+import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import Navbar from './Navbar';
+import Footer from './Footer';
+import './NewsPage.css';
+
+const NewsPage = () => {
+    const [articles, setArticles] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState('');
+
+    useEffect(() => {
+        const fetchArticles = async () => {
+            try {
+                const response = await fetch('http://localhost:5000/api/news');
+                if (!response.ok) throw new Error('Failed to fetch articles');
+                const data = await response.json();
+                setArticles(data);
+            } catch (err) {
+                setError(err.message);
+            } finally {
+                setLoading(false);
+            }
+        };
+        fetchArticles();
+    }, []);
+
+    return (
+        <div>
+            <Navbar />
+            <main className="news-page-container">
+                <header className="news-page-header">
+                    <h1>اخبار و مقالات</h1>
+                    <p>آخرین اخبار و مقالات آموزشی را در اینجا بیابید.</p>
+                </header>
+                <div className="articles-grid">
+                    {loading && <p>در حال بارگذاری مقالات...</p>}
+                    {error && <p className="error-message">{error}</p>}
+                    {articles.map(article => (
+                        <Link to={`/news/${article.id}`} key={article.id} className="article-card">
+                            <img src={article.imageUrl ? `http://localhost:5000${article.imageUrl}` : 'https://placehold.co/300x200/2c3e50/FFFFFF?text=مقاله'} alt={article.title} />
+                            <div className="article-card-content">
+                                <h3>{article.title}</h3>
+                                <p>{article.summary}</p>
+                                <span className="read-more">ادامه مطلب...</span>
+                            </div>
+                        </Link>
+                    ))}
+                </div>
+            </main>
+            <Footer />
+        </div>
+    );
+};
+
+export default NewsPage;

--- a/client/src/components/admin/UserDetailPage.css
+++ b/client/src/components/admin/UserDetailPage.css
@@ -1,0 +1,57 @@
+.user-detail-page {
+    direction: rtl;
+}
+
+.user-detail-page h2, .user-detail-page h3 {
+    text-align: right;
+    margin-bottom: 1rem;
+}
+
+.user-info-card {
+    background: #fff;
+    padding: 1.5rem;
+    border-radius: 8px;
+    margin-bottom: 2rem;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.user-info-card p {
+    text-align: right;
+    margin: 0.5rem 0;
+}
+
+.children-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 1.5rem;
+}
+
+.child-card {
+    background: #fff;
+    padding: 1rem;
+    border-radius: 8px;
+    text-align: center;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.child-card img {
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    object-fit: cover;
+    margin-bottom: 1rem;
+}
+
+.child-card p {
+    font-weight: bold;
+    margin-bottom: 1rem;
+}
+
+.btn-view-profile {
+    background-color: #1abc9c;
+    color: white;
+    padding: 8px 12px;
+    text-decoration: none;
+    border-radius: 4px;
+    display: inline-block;
+}

--- a/client/src/components/admin/UserDetailPage.js
+++ b/client/src/components/admin/UserDetailPage.js
@@ -1,0 +1,74 @@
+import React, { useState, useEffect } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import './UserDetailPage.css';
+
+const UserDetailPage = () => {
+    const { userId } = useParams();
+    const [user, setUser] = useState(null);
+    const [children, setChildren] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState('');
+
+    useEffect(() => {
+        const fetchData = async () => {
+            setLoading(true);
+            try {
+                const adminUser = JSON.parse(localStorage.getItem('loggedInUser'));
+
+                // Fetch user details
+                const userResponse = await fetch(`http://localhost:5000/api/users/${userId}`);
+                if (!userResponse.ok) throw new Error('Failed to fetch user details');
+                const userData = await userResponse.json();
+                setUser(userData);
+
+                // Fetch user's children
+                const childrenResponse = await fetch(`http://localhost:5000/api/admin/users/${userId}/children`, {
+                    headers: { 'x-user-id': adminUser.id }
+                });
+                if (!childrenResponse.ok) throw new Error("Failed to fetch user's children");
+                const childrenData = await childrenResponse.json();
+                setChildren(childrenData);
+
+            } catch (err) {
+                setError(err.message);
+            } finally {
+                setLoading(false);
+            }
+        };
+        fetchData();
+    }, [userId]);
+
+    if (loading) return <p>در حال بارگذاری اطلاعات کاربر...</p>;
+    if (error) return <p>خطا: {error}</p>;
+    if (!user) return <p>کاربر یافت نشد.</p>;
+
+    return (
+        <div className="user-detail-page">
+            <h2>جزئیات کاربر: {user.username}</h2>
+            <div className="user-info-card">
+                <p><strong>ID:</strong> {user.id}</p>
+                <p><strong>ایمیل:</strong> {user.email}</p>
+                <p><strong>ادمین:</strong> {user.isAdmin ? 'بله' : 'خیر'}</p>
+            </div>
+
+            <h3>فرزندان ثبت‌شده</h3>
+            <div className="children-list">
+                {children.length > 0 ? (
+                    children.map(child => (
+                        <div key={child.id} className="child-card">
+                            <img src={child.avatar.startsWith('http') ? child.avatar : `http://localhost:5000${child.avatar}`} alt={child.name} />
+                            <p>{child.name}</p>
+                            <Link to={`/health-profile/${child.id}`} className="btn-view-profile">
+                                مشاهده پروفایل سلامت
+                            </Link>
+                        </div>
+                    ))
+                ) : (
+                    <p>این کاربر فرزندی ثبت نکرده است.</p>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default UserDetailPage;

--- a/client/src/components/admin/UserManagement.js
+++ b/client/src/components/admin/UserManagement.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import './UserManagement.css';
 import EditUserModal from './EditUserModal';
 
@@ -109,7 +110,9 @@ const UserManagement = () => {
                     {users.map(user => (
                         <tr key={user.id}>
                             <td>{user.id}</td>
-                            <td>{user.username}</td>
+                            <td>
+                                <Link to={`/admin/users/${user.id}`}>{user.username}</Link>
+                            </td>
                             <td>{user.email}</td>
                             <td>{user.isAdmin ? 'بله' : 'خیر'}</td>
                             <td>

--- a/server/server.js
+++ b/server/server.js
@@ -149,6 +149,13 @@ app.delete('/api/admin/users/:id', isAdmin, (req, res) => {
     res.status(200).json({ message: 'کاربر با موفقیت حذف شد' });
 });
 
+app.get('/api/admin/users/:userId/children', isAdmin, (req, res) => {
+    const { userId } = req.params;
+    const userChildren = children.filter(c => c.userId === parseInt(userId));
+    res.json(userChildren);
+});
+
+
 // --- Content Management Routes ---
 app.get('/api/banners', (req, res) => {
     res.json(banners);


### PR DESCRIPTION
This commit addresses user feedback on the previously created admin panel by integrating its features into the public-facing application.

- **Banner Display**: The main dashboard now fetches and displays banners from the API in the carousel component.
- **Public News/Articles**: A new public-facing section for news and articles has been created. It includes a list page (`/news`) and a detail page (`/news/:id`), with a link added to the main navbar.
- **Admin User Detail View**: The admin panel's user management has been enhanced. Admins can now click on a user to navigate to a new detail page that displays the user's information and a list of all children registered to that user. A new API endpoint (`/api/admin/users/:userId/children`) was added to support this.