### PR TITLE
fix: Add data validation to prevent carousel bug

### DIFF
--- a/client/src/components/DashboardPage.js
+++ b/client/src/components/DashboardPage.js
@@ -26,9 +26,11 @@ const DashboardPage = () => {
                 const bannersResponse = await fetch('http://localhost:5000/api/banners');
                 if (bannersResponse.ok) {
                     const data = await bannersResponse.json();
-                    const formattedBanners = data.map(banner => ({
-                        id: banner.id, // Pass the id for the key prop
-                        image: `http://localhost:5000${banner.imageUrl}`,
+                    const formattedBanners = data
+                        .filter(banner => banner.imageUrl && banner.imageUrl.trim() !== '')
+                        .map(banner => ({
+                            id: banner.id, // Pass the id for the key prop
+                            image: `http://localhost:5000${banner.imageUrl}`,
                         title: banner.title,
                         link: banner.link,
                     }));


### PR DESCRIPTION
This commit fixes a persistent bug where the banner carousel would show a 'white slide'. The root cause was determined to be malformed banner data (likely a missing `imageUrl`) being passed to the component.

A filter has been added to `DashboardPage.js` to validate the banner data fetched from the API. Only banners that have a valid, non-empty `imageUrl` are processed and passed to the `Carousel` component. This prevents bad data from breaking the carousel's rendering logic.