### PR TITLE
fix: Resolve carousel 'white slide' bug with CSS

### DIFF
--- a/client/src/components/Carousel.css
+++ b/client/src/components/Carousel.css
@@ -19,6 +19,14 @@
     width: 100%;
 }
 
+/* Ensure both Link (a) and div children behave as blocks */
+.carousel-item > a,
+.carousel-item > div {
+    display: block;
+    text-decoration: none;
+    color: inherit;
+}
+
 .carousel-inner img {
     width: 100%;
     height: 400px;


### PR DESCRIPTION
This commit fixes a persistent bug where the second banner in the carousel would appear as a 'white slide'.

The root cause was identified as a layout collapse issue. When a slide's content was wrapped in a `Link` (<a>) tag, it did not behave as a proper block-level flex item by default, causing its dimensions to collapse.

A CSS rule has been added to `Carousel.css` to ensure that the direct children of a `.carousel-item` (whether `<a>` or `<div>`) are set to `display: block`. This guarantees consistent layout behavior for all slides and resolves the rendering bug.