### PR TITLE
debug: Simplify Carousel component for debugging

### DIFF
--- a/client/src/components/Carousel.js
+++ b/client/src/components/Carousel.js
@@ -1,66 +1,34 @@
 import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
 import './Carousel.css';
 
+// Using a simple default for structure, but it will be replaced by props.
 const defaultSlides = [
-    {
-        image: 'https://images.unsplash.com/photo-1506748686214-e9df14d4d9d0?ixlib=rb-1.2.1&auto=format&fit=crop&w=1200&q=80',
-        title: 'به سامانه رشد خوش آمدید',
-        subtitle: 'محلی برای پایش و مراقبت از سلامت فرزندان شما',
-        link: '/about'
-    },
-    {
-        image: 'https://images.unsplash.com/photo-1501785888041-af3ef285b470?ixlib=rb-1.2.1&auto=format&fit=crop&w=1200&q=80',
-        title: 'نمودارهای رشد استاندارد',
-        subtitle: 'بر اساس آخرین داده‌های سازمان بهداشت جهانی',
-        link: '/my-children'
-    }
+    { id: 1, image: 'https://placehold.co/1200x400/cccccc/ffffff?text=Default+Slide' }
 ];
 
 const Carousel = ({ slides = defaultSlides }) => {
     const [currentIndex, setCurrentIndex] = useState(0);
 
     useEffect(() => {
-        if (slides.length === 0) return;
+        if (slides.length < 2) return; // No need to slide if there's only one or zero slides
         const interval = setInterval(() => {
             setCurrentIndex(prev => (prev + 1) % slides.length);
         }, 5000);
         return () => clearInterval(interval);
     }, [slides.length]);
 
-    if (slides.length === 0) {
+    if (!slides || slides.length === 0) {
         return null; // Don't render anything if there are no slides
     }
-
-    const handleImageError = (e) => {
-        e.target.onerror = null; // prevent infinite loop
-        e.target.src = 'https://placehold.co/1200x400/cccccc/ffffff?text=Image+Not+Found';
-    };
 
     return (
         <div className="carousel">
             <div className="carousel-inner" style={{ transform: `translateX(-${currentIndex * 100}%)` }}>
-                {slides.map((slide) => {
-                    const slideContent = (
-                        <>
-                            <img src={slide.image} alt={slide.title} onError={handleImageError} />
-                            <div className="carousel-caption">
-                                <h2>{slide.title}</h2>
-                                {slide.subtitle && <p>{slide.subtitle}</p>}
-                            </div>
-                        </>
-                    );
-
-                    return (
-                        <div className="carousel-item" key={slide.id || slide.title}>
-                            {slide.link ? (
-                                <Link to={slide.link}>{slideContent}</Link>
-                            ) : (
-                                <div>{slideContent}</div>
-                            )}
-                        </div>
-                    );
-                })}
+                {slides.map((slide) => (
+                    <div className="carousel-item" key={slide.id || slide.title}>
+                        <img src={slide.image} alt={slide.title || 'Banner Image'} />
+                    </div>
+                ))}
             </div>
         </div>
     );


### PR DESCRIPTION
This commit temporarily simplifies the Carousel.js component to its bare minimum to help diagnose a persistent 'white slide' rendering bug.

All logic related to links, captions, and image error handling has been removed. The component now only renders the banner images and the core sliding mechanism. This is intended to isolate the problem and verify if the basic sliding works correctly with multiple items.

This is a temporary, non-production commit for debugging purposes.