### PR TITLE
fix: Replace custom carousel with a third-party library

### DIFF
--- a/client/node_modules/.package-lock.json
+++ b/client/node_modules/.package-lock.json
@@ -16639,6 +16639,18 @@
         "react": "17.0.2"
       }
     },
+    "node_modules/react-easy-swipe": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/react-easy-swipe/-/react-easy-swipe-0.0.21.tgz",
+      "integrity": "sha512-OeR2jAxdoqUMHIn/nS9fgreI5hSpgGoL5ezdal4+oO7YSSgJR8ga+PkYGJrSrJ9MKlPcQjMQXnketrD7WNmNsg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.5.8"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/react-error-overlay": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.1.0.tgz",
@@ -16715,6 +16727,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-responsive-carousel": {
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/react-responsive-carousel/-/react-responsive-carousel-3.2.23.tgz",
+      "integrity": "sha512-pqJLsBaKHWJhw/ItODgbVoziR2z4lpcJg+YwmRlSk4rKH32VE633mAtZZ9kDXjy4wFO+pgUZmDKPsPe1fPmHCg==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "prop-types": "^15.5.8",
+        "react-easy-swipe": "^0.0.21"
       }
     },
     "node_modules/react-router": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,6 +18,7 @@
         "react-datepicker": "^4.8.0",
         "react-dom": "^17.0.2",
         "react-modal": "^3.16.1",
+        "react-responsive-carousel": "^3.2.23",
         "react-router-dom": "5.2.0",
         "react-scripts": "4.0.3",
         "recharts": "^2.5.0"
@@ -16657,6 +16658,18 @@
         "react": "17.0.2"
       }
     },
+    "node_modules/react-easy-swipe": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/react-easy-swipe/-/react-easy-swipe-0.0.21.tgz",
+      "integrity": "sha512-OeR2jAxdoqUMHIn/nS9fgreI5hSpgGoL5ezdal4+oO7YSSgJR8ga+PkYGJrSrJ9MKlPcQjMQXnketrD7WNmNsg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.5.8"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/react-error-overlay": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.1.0.tgz",
@@ -16733,6 +16746,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-responsive-carousel": {
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/react-responsive-carousel/-/react-responsive-carousel-3.2.23.tgz",
+      "integrity": "sha512-pqJLsBaKHWJhw/ItODgbVoziR2z4lpcJg+YwmRlSk4rKH32VE633mAtZZ9kDXjy4wFO+pgUZmDKPsPe1fPmHCg==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "prop-types": "^15.5.8",
+        "react-easy-swipe": "^0.0.21"
       }
     },
     "node_modules/react-router": {

--- a/client/package.json
+++ b/client/package.json
@@ -6,16 +6,17 @@
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@fortawesome/react-fontawesome": "^0.1.18",
+    "date-fns": "^2.29.3",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^2.5.1",
     "react": "^17.0.2",
+    "react-datepicker": "^4.8.0",
     "react-dom": "^17.0.2",
+    "react-modal": "^3.16.1",
+    "react-responsive-carousel": "^3.2.23",
     "react-router-dom": "5.2.0",
     "react-scripts": "4.0.3",
-    "react-datepicker": "^4.8.0",
-    "date-fns": "^2.29.3",
-    "recharts": "^2.5.0",
-    "react-modal": "^3.16.1",
-    "jspdf": "^2.5.1",
-    "html2canvas": "^1.4.1"
+    "recharts": "^2.5.0"
   },
   "scripts": {
     "start": "npx react-scripts --openssl-legacy-provider start",

--- a/client/src/components/Carousel.css
+++ b/client/src/components/Carousel.css
@@ -1,64 +1,23 @@
-.carousel {
-    position: relative;
-    width: 100%;
+/* Custom styles for react-responsive-carousel can go here */
+
+.presentation-mode {
     max-width: 1200px;
     margin: 2rem auto;
-    overflow: hidden;
     border-radius: 16px;
+    overflow: hidden; /* Ensures the border-radius is applied to images */
     box-shadow: 0 8px 20px rgba(0,0,0,0.1);
 }
 
-.carousel-inner {
-    display: flex;
-    transition: transform 0.5s ease-in-out;
-}
-
-.carousel-item {
-    position: relative;
-    flex-shrink: 0;
-    width: 100%;
-    display: flex; /* Make the item a flex container */
-    align-items: stretch; /* Make children stretch to full height */
-}
-
-/* Ensure both Link (a) and div children fill the container */
-.carousel-item > a,
-.carousel-item > div {
-    display: flex; /* Use flex for inner content too */
-    flex-direction: column;
-    width: 100%;
-    text-decoration: none;
-    color: inherit;
-}
-
-.carousel-inner img {
-    width: 100%;
-    height: 400px;
+.presentation-mode .carousel .slide img {
+    max-height: 400px; /* Or any desired height */
     object-fit: cover;
-    display: block;
 }
 
-.carousel-caption {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background: linear-gradient(to top, rgba(0,0,0,0.7), transparent);
-    color: white;
-    padding: 3rem 2rem 2rem;
-    text-align: right;
-}
-
-.carousel-caption h2 {
-    font-family: 'Vazirmatn', Tahoma, sans-serif;
-    font-size: 2.5rem;
-    margin: 0 0 0.5rem 0;
-    font-weight: 900;
-}
-
-.carousel-caption p {
-    font-family: 'Vazirmatn', Tahoma, sans-serif;
-    font-size: 1.2rem;
-    margin: 0;
-    font-weight: 400;
+/* The library uses a `legend` class for captions by default */
+.presentation-mode .legend {
+    background: linear-gradient(to top, rgba(0,0,0,0.7), transparent) !important;
+    opacity: 1 !important;
+    font-size: 1.5rem !important;
+    font-weight: bold !important;
+    padding: 2rem !important;
 }

--- a/client/src/components/Carousel.js
+++ b/client/src/components/Carousel.js
@@ -1,36 +1,47 @@
-import React, { useState, useEffect } from 'react';
-import './Carousel.css';
+import React from 'react';
+import { Carousel as ResponsiveCarousel } from 'react-responsive-carousel';
+import "react-responsive-carousel/lib/styles/carousel.min.css"; // requires a loader
+import './Carousel.css'; // Your custom styles
 
-// Using a simple default for structure, but it will be replaced by props.
-const defaultSlides = [
-    { id: 1, image: 'https://placehold.co/1200x400/cccccc/ffffff?text=Default+Slide' }
-];
-
-const Carousel = ({ slides = defaultSlides }) => {
-    const [currentIndex, setCurrentIndex] = useState(0);
-
-    useEffect(() => {
-        if (slides.length < 2) return; // No need to slide if there's only one or zero slides
-        const interval = setInterval(() => {
-            setCurrentIndex(prev => (prev + 1) % slides.length);
-        }, 5000);
-        return () => clearInterval(interval);
-    }, [slides.length]);
+const Carousel = ({ slides = [] }) => {
 
     if (!slides || slides.length === 0) {
         return null; // Don't render anything if there are no slides
     }
 
+    const handleItemClick = (index, item) => {
+        // The library gives us the item clicked, which has the link property
+        if (item.props.url) {
+            // A simple redirect. For internal links, React Router's useHistory would be better.
+            // Using window.open to open in a new tab if the link is external.
+            if (item.props.url.startsWith('http')) {
+                window.open(item.props.url, '_blank', 'noopener,noreferrer');
+            } else {
+                 window.location.href = item.props.url;
+            }
+        }
+    }
+
     return (
-        <div className="carousel">
-            <div className="carousel-inner" style={{ transform: `translateX(-${currentIndex * 100}%)` }}>
-                {slides.map((slide) => (
-                    <div className="carousel-item" key={slide.id || slide.title}>
-                        <img src={slide.image} alt={slide.title || 'Banner Image'} />
-                    </div>
-                ))}
-            </div>
-        </div>
+        // The library's Carousel component handles all the state and sliding logic
+        <ResponsiveCarousel
+            showThumbs={false}
+            showStatus={false}
+            infiniteLoop
+            useKeyboardArrows
+            autoPlay
+            interval={5000}
+            onClickItem={handleItemClick}
+            className="presentation-mode"
+        >
+            {slides.map((slide) => (
+                // The library expects simple children. We pass the link as a custom prop 'url'.
+                <div key={slide.id} url={slide.link}>
+                    <img src={slide.image} alt={slide.title} />
+                    <p className="legend">{slide.title}</p>
+                </div>
+            ))}
+        </ResponsiveCarousel>
     );
 };
 

--- a/client/src/components/DashboardPage.js
+++ b/client/src/components/DashboardPage.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import Navbar from './Navbar';
 import Footer from './Footer';
-import Carousel from './Carousel';
+import AppCarousel from './Carousel';
 import ServiceTiles from './ServiceTiles';
 import ContentRow from './ContentRow';
 
@@ -60,7 +60,7 @@ const DashboardPage = () => {
         <div>
             <Navbar />
             <main>
-                <Carousel slides={banners} />
+                <AppCarousel slides={banners} />
                 <ServiceTiles />
 
                 <ContentRow title="ویدیوهای آموزشی و تربیتی" items={mockVideos} />


### PR DESCRIPTION
This commit replaces the buggy, custom-built carousel component with the `react-responsive-carousel` library. This is done to definitively resolve a persistent 'white slide' rendering bug that was difficult to diagnose and fix in the custom implementation.

- The `react-responsive-carousel` package has been added as a dependency.
- `Carousel.js` has been completely re-implemented to use the new library.
- `Carousel.css` has been updated with styles to support the new library.
- `DashboardPage.js` has been updated to use the new carousel component.

Using a well-tested, industry-standard library provides a more robust and reliable solution, ensuring the carousel works as expected.