### PR TITLE
fix: Add onError handler to carousel images

### DIFF
--- a/client/src/components/Carousel.js
+++ b/client/src/components/Carousel.js
@@ -9,6 +9,11 @@ const Carousel = ({ slides = [] }) => {
         return null; // Don't render anything if there are no slides
     }
 
+    const handleImageError = (e) => {
+        e.target.onerror = null; // prevent infinite loop
+        e.target.src = 'https://placehold.co/1200x400/cccccc/ffffff?text=Image+Not+Available';
+    };
+
     const handleItemClick = (index, item) => {
         // The library gives us the item clicked, which has the link property
         if (item.props.url) {
@@ -37,7 +42,7 @@ const Carousel = ({ slides = [] }) => {
             {slides.map((slide) => (
                 // The library expects simple children. We pass the link as a custom prop 'url'.
                 <div key={slide.id} url={slide.link}>
-                    <img src={slide.image} alt={slide.title} />
+                    <img src={slide.image} alt={slide.title} onError={handleImageError} />
                     <p className="legend">{slide.title}</p>
                 </div>
             ))}


### PR DESCRIPTION
This commit provides a final, robust fix for the persistent 'white slide' bug in the banner carousel.

After extensive debugging, the root cause was identified as an environmental issue where uploaded image files were not being persisted, leading to broken image URLs in the database.

To handle this gracefully, an `onError` event handler has been added to the `<img>` tags within the carousel. If an image source fails to load, this handler will replace it with a standard placeholder image. This prevents a blank space from being rendered and makes the component resilient to data inconsistencies.