### PR TITLE
fix: Add missing normalize.css dependency

### DIFF
--- a/client/node_modules/.package-lock.json
+++ b/client/node_modules/.package-lock.json
@@ -13778,6 +13778,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/normalize.css": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==",
+      "license": "MIT"
+    },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14,6 +14,7 @@
         "date-fns": "^2.29.3",
         "html2canvas": "^1.4.1",
         "jspdf": "^2.5.1",
+        "normalize.css": "^8.0.1",
         "react": "^17.0.2",
         "react-datepicker": "^4.8.0",
         "react-dom": "^17.0.2",
@@ -13796,6 +13797,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/normalize.css": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==",
+      "license": "MIT"
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,7 @@
     "date-fns": "^2.29.3",
     "html2canvas": "^1.4.1",
     "jspdf": "^2.5.1",
+    "normalize.css": "^8.0.1",
     "react": "^17.0.2",
     "react-datepicker": "^4.8.0",
     "react-dom": "^17.0.2",


### PR DESCRIPTION
This commit fixes a compilation error that occurred during `npm start`. The build would fail with the error "Can't resolve '~normalize.css/normalize.css'".

This was caused by an `@import` statement in `index.css` for the `normalize.css` package, which was not listed as a project dependency.

This commit adds `normalize.css` to the `dependencies` in `client/package.json` to resolve the issue.