### PR TITLE
fix: Correct CSS import path for carousel library

### DIFF
--- a/client/src/components/Carousel.js
+++ b/client/src/components/Carousel.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Carousel as ResponsiveCarousel } from 'react-responsive-carousel';
-import "react-responsive-carousel/lib/styles/carousel.min.css"; // requires a loader
+import "~react-responsive-carousel/lib/styles/carousel.min.css"; // requires a loader
 import './Carousel.css'; // Your custom styles
 
 const Carousel = ({ slides = [] }) => {


### PR DESCRIPTION
This commit fixes a bug where the `react-responsive-carousel` component was not rendering correctly because its required CSS was not being loaded.

The issue was traced to an incorrect import path. Based on how other node module CSS is imported in this project (e.g., `normalize.css`), the path required a `~` prefix for webpack to resolve it correctly from the `node_modules` directory.

The import statement in `Carousel.js` has been changed from `import "react-responsive-carousel/..."` to `import "~react-responsive-carousel/..."` to fix the issue. This should resolve the 'white slide' bug.