### PR TITLE
Fix banner display and standardize article box sizes

### DIFF
--- a/client/src/components/Carousel.js
+++ b/client/src/components/Carousel.js
@@ -30,6 +30,7 @@ const Carousel = ({ slides = [] }) => {
     return (
         // The library's Carousel component handles all the state and sliding logic
         <ResponsiveCarousel
+            key={slides.length}
             showThumbs={false}
             showStatus={false}
             infiniteLoop


### PR DESCRIPTION
This commit addresses two primary issues:

1.  Banners not displaying correctly:
    -   The API endpoint for banners (`/api/banners`) was aggressively cached by the browser. A `Cache-Control: no-store` header has been added to prevent this.
    -   The static image files in `/uploads` were also being cached, leading to browsers not re-fetching them. Caching headers (`ETag`, `Last-Modified`) have been disabled for this route.
    -   The `react-responsive-carousel` component was not re-rendering correctly when new slides were added asynchronously. A `key` prop has been added to force a re-render.
    -   A minor CSS import path for the carousel was also corrected.

2.  Article boxes having uneven sizes:
    -   CSS Flexbox properties have been applied to the content card components to ensure they have a uniform height regardless of the amount of text content.