### PR TITLE
fix: Configure tailwindcss-rtl for proper RTL support

### DIFF
--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -6,5 +6,7 @@ module.exports = {
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [
+    require('tailwindcss-rtl'),
+  ],
 }


### PR DESCRIPTION
This commit adds the `tailwindcss-rtl` plugin to the TailwindCSS configuration. This is necessary to correctly generate styles for right-to-left languages, which should fix the layout issues reported by the user.