### PR TITLE
fix: Final responsive fixes for tiles, modals, and scrolling

### DIFF
--- a/client/src/components/ServiceTiles.css
+++ b/client/src/components/ServiceTiles.css
@@ -48,14 +48,8 @@
         gap: 0.8rem;
     }
     .tile {
-        /*
-         Allow tiles to grow and shrink, with a preferred base size.
-         On a typical mobile screen (e.g., 360px wide), this allows
-         for two tiles to sit side-by-side comfortably.
-        */
         flex-basis: calc(50% - 1rem); /* 2 items per row with gap */
-        height: auto; /* Auto height for content */
-        min-height: 110px;
+        height: 120px; /* Set a fixed height to ensure uniformity */
         padding: 0.8rem 0.5rem;
     }
     .tile-icon {


### PR DESCRIPTION
This commit addresses several layout issues based on detailed user feedback to complete the responsive styling of the application.

1.  **Service Tiles:** All service tiles on the homepage now have a fixed height in the mobile view to ensure they are uniform and do not misalign the grid.
2.  **Notification Modal:** The breakpoint for the notification modal has been increased to ensure it displays correctly on tablets and doesn't appear off-screen.
3.  **Video Section:** The video row on the homepage now scrolls horizontally on desktop, as requested.
4.  **Content Cards:** All content cards (for articles, etc.) now have a minimum height to ensure they align correctly when they wrap.