### PR TITLE
fix: Enforce uniform width for service tiles on desktop

### DIFF
--- a/client/src/components/ServiceTiles.css
+++ b/client/src/components/ServiceTiles.css
@@ -14,7 +14,9 @@
 
 .tile {
     background-color: white;
+    width: 150px; /* Set a fixed width */
     flex-basis: 150px; /* Use flex-basis for initial size */
+    flex-shrink: 0; /* Prevent shrinking */
     height: 120px;
     border-radius: 12px;
     display: flex;


### PR DESCRIPTION
This commit sets an explicit `width` and `flex-shrink: 0` on the service tiles to ensure they all have the same width in the desktop view, regardless of their text content. This resolves the layout misalignment issue reported by the user.