### PR TITLE
Fix: Use nodemon for dev script

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "dev": "node server.js"
+    "dev": "nodemon server.js"
   },
   "dependencies": {
     "express": "^4.17.1",


### PR DESCRIPTION
- Changed the `dev` script in `server/package.json` to use `nodemon` instead of `node`.
- This provides better error reporting and automatic server restarts during development.