### PR TITLE
Fix: Add missing app.listen call in server.js

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -320,3 +320,7 @@ app.delete('/api/admin/videos/:id', isAdmin, (req, res) => {
 app.get('/api/podcasts', (req, res) => {
     res.json(podcasts);
 });
+
+app.listen(port, () => {
+    console.log(`Roshdyar server is listening on port ${port}`);
+});


### PR DESCRIPTION
The server was exiting immediately after starting because the `app.listen` call was missing. This change adds the necessary code to start the server and keep it running to listen for requests.