### PR TITLE
Fix navigation, alignment, and upload bugs across child pages

### DIFF
--- a/client/src/components/AddChildPage.css
+++ b/client/src/components/AddChildPage.css
@@ -1,24 +1,24 @@
 .add-child-page-v2 { background-color: #f0f4f8; min-height: 100vh; }
 
 .add-child-page-v2 .page-nav-final {
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
+    position: relative;
+    display: flex;
     align-items: center;
+    justify-content: flex-start;
     padding: 0.8rem 1.5rem;
     background-color: #fff;
     box-shadow: 0 2px 4px rgba(0,0,0,0.05);
 }
 
 .add-child-page-v2 .page-nav-final h1 {
-    grid-column: 2;
-    justify-self: center;
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
     margin: 0;
     font-size: 1.4rem;
 }
 
 .back-btn-add-child {
-    grid-column: 1;
-    justify-self: start;
     background: none;
     border: none;
     cursor: pointer;

--- a/client/src/components/AddChildPage.js
+++ b/client/src/components/AddChildPage.js
@@ -99,7 +99,11 @@ const AddChildPage = () => {
             if (avatarFile) {
                 const avatarUploadData = new FormData();
                 avatarUploadData.append('avatar', avatarFile);
-                const avatarRes = await fetch('http://localhost:5000/api/upload', { method: 'POST', body: avatarUploadData });
+                const avatarRes = await fetch('http://localhost:5000/api/upload', {
+                    method: 'POST',
+                    headers: { 'x-user-id': loggedInUser.id },
+                    body: avatarUploadData
+                });
                 if (!avatarRes.ok) throw new Error('Failed to upload avatar image');
                 const avatarResult = await avatarRes.json();
                 avatarPath = avatarResult.filePath.replace(/\\/g, "/");
@@ -165,7 +169,6 @@ const AddChildPage = () => {
                     <span>بازگشت</span>
                 </button>
                 <h1>افزودن کودک جدید</h1>
-                <div className="nav-placeholder"></div>
             </nav>
             <div className="add-child-form-container-v2">
                 <form onSubmit={handleSubmit} className="add-child-form">


### PR DESCRIPTION
This commit addresses several issues across the child management pages:

- Fixed a bug on the 'My Children' page where the 'View Profile' button used `window.location.href` instead of `history.push`, causing unnecessary page reloads.
- Resolved a memory leak in `HealthProfilePage` by implementing a cleanup function with `AbortController` to cancel pending fetch requests when the component unmounts.
- Fixed an avatar upload failure in `AddChildPage` by adding the necessary `x-user-id` authentication header to the upload request.
- Corrected the header styling on `MyChildrenPage`, `HealthProfilePage`, and `AddChildPage` to properly center the title using a more robust flexbox and absolute positioning approach.