### PR TITLE
Fix: Add x-user-id header to children API request

### DIFF
--- a/client/src/components/ServiceTiles.js
+++ b/client/src/components/ServiceTiles.js
@@ -26,7 +26,12 @@ const ServiceTiles = () => {
     const handleServiceClick = async (serviceId) => {
         console.log(`handleServiceClick triggered for service: ${serviceId}`);
         try {
-            const response = await fetch('http://localhost:5000/api/children');
+            const userId = localStorage.getItem('userId');
+            const response = await fetch('http://localhost:5000/api/children', {
+                headers: {
+                    'x-user-id': userId,
+                },
+            });
             const data = await response.json();
             console.log(`Found ${data.length} children.`);
 


### PR DESCRIPTION
This commit fixes a 401 Unauthorized error that occurred when clicking the 'growth-chart' service tile. The fetch request to '/api/children' was missing user authentication.

The fix retrieves the 'userId' from localStorage and adds it to the request as an 'x-user-id' header, allowing the server to properly authenticate the user and return their children's data.