### PR TITLE
Fix(client): Correctly retrieve user ID from localStorage

### DIFF
--- a/client/src/components/ServiceTiles.js
+++ b/client/src/components/ServiceTiles.js
@@ -26,7 +26,15 @@ const ServiceTiles = () => {
     const handleServiceClick = async (serviceId) => {
         console.log(`handleServiceClick triggered for service: ${serviceId}`);
         try {
-            const userId = localStorage.getItem('userId');
+            const loggedInUser = JSON.parse(localStorage.getItem('loggedInUser'));
+            const userId = loggedInUser ? loggedInUser.id : null;
+
+            if (!userId) {
+                alert('لطفا برای مشاهده این بخش ابتدا وارد شوید.');
+                history.push('/login');
+                return;
+            }
+
             const response = await fetch('http://localhost:5000/api/children', {
                 headers: {
                     'x-user-id': userId,
@@ -39,14 +47,14 @@ const ServiceTiles = () => {
             }
 
             const data = await response.json();
-            console.log(`Found ${data.length} children.`);
+            console.log(`Found ${data.length} children for user ${userId}.`);
 
             if (data.length === 0) {
-                console.log('Navigating to /add-child');
+                console.log('No children found, navigating to /add-child');
                 alert('ابتدا باید حداقل یک کودک اضافه کنید.');
                 history.push('/add-child');
             } else {
-                console.log('Opening child selection modal.');
+                console.log(`Found ${data.length} children. Opening child selection modal.`);
                 setChildren(data);
                 setSelectedService(serviceId);
                 setModalIsOpen(true);

--- a/server/server.js
+++ b/server/server.js
@@ -178,7 +178,7 @@ app.put('/api/users/:id', (req, res) => {
 app.get('/api/children', (req, res) => {
     const userId = req.headers['x-user-id'];
     if (!userId) return res.status(401).json({ message: 'User ID is required' });
-    const userChildren = children.filter(c => c.userId === Number(userId));
+    const userChildren = children.filter(c => c.userId === parseInt(userId));
     res.json(userChildren);
 });
 


### PR DESCRIPTION
Previously, when a user with children clicked the 'Growth Chart' tile, they were incorrectly redirected to the 'Add Child' page.

The issue was caused by an inconsistency in how the user ID was retrieved from `localStorage` in the `ServiceTiles.js` component. The code was attempting to get the ID from a key named `'userId'`, which does not exist. The correct user information is stored as a JSON object under the key `'loggedInUser'`.

This commit fixes the bug by updating `ServiceTiles.js` to:
1.  Retrieve the `'loggedInUser'` object from `localStorage`.
2.  Parse the JSON object to get the user's `id`.
3.  Use this correct `id` when fetching the list of children from the API.

This ensures the backend receives the correct user ID, allowing the application to display the list of children as expected.