### PR TITLE
fix: Resolve calendar visibility with global CSS override

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -57,3 +57,14 @@ body {
 .react-datepicker__year-dropdown {
     background-color: #fff !important;
 }
+
+/*
+  Global fix for the react-modern-calendar-datepicker.
+  The calendar was being clipped by parent elements with `overflow: hidden`.
+  Using `position: fixed` ensures the calendar always renders on top of the viewport.
+  A high z-index is required to make sure it appears above modal overlays.
+*/
+.responsive-calendar {
+    position: fixed !important;
+    z-index: 2000 !important;
+}


### PR DESCRIPTION
This commit fixes a critical bug where the `react-modern-calendar-datepicker` component was not visible after being implemented.

The root cause was identified as a CSS clipping issue. Parent containers with `overflow: hidden` were hiding the calendar when it tried to render.

The fix involves adding a new global CSS rule to `index.css` that sets `position: fixed` and a high `z-index` on the calendar's wrapper. This ensures the calendar always appears on top of the viewport, above all other elements, which is the correct and expected behavior for a date picker popup.