### PR TITLE
Set up dev environment + document Cursor Cloud setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,17 @@ npm start --prefix client
 ```
 
 سرور روی پورت `5000` و کلاینت روی پورت `3000` اجرا خواهد شد.
+
+## Cursor Cloud specific instructions
+
+Dependencies are refreshed automatically on VM startup by the environment update script (`npm install` for both `server` and `client`), so you normally don't need to install anything manually. Standard run commands are already documented above and in each `package.json`.
+
+Non-obvious notes for this codebase:
+
+- **Backend "database" is a JSON file.** The server uses `server/db.json` as its store (loaded/saved in `server/server.js`); there is no external database, cache, or queue to run. Data written during testing persists to `server/db.json`.
+- **Seeded admin account:** username `admin`, password `admin` (in `server/db.json`). Use it to log in and reach the dashboard/admin panel.
+- **API base URL is hardcoded.** The React client calls `http://localhost:5000` directly (see `client/src/components/*.js`); it is not configurable via env. The server must run on port `5000` and the client on `3000` for the app to work end to end.
+- **Node 22 + react-scripts 4 (OpenSSL).** The client's `start`/`build` scripts already pass `--openssl-legacy-provider`, which is required for react-scripts 4.0.3 to compile on this Node version. Don't remove it. When starting the client non-interactively, set `BROWSER=none` to stop it from trying to launch a browser.
+- **No real lint/test suites.** `client` has no test files (`npm test --prefix client` just starts CRA/Jest watch mode); ESLint runs implicitly via react-scripts during `start`/`build`. The `server` has no tests.
+- **Vendored `node_modules`.** `node_modules` is committed to the repo. Avoid staging changes under `node_modules/` (including `node_modules/.package-lock.json`) when committing.
+- **Stray `client/client` folder** is a leftover artifact and is not used by the app; ignore it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the local development environment for the Roshdyar app (React client + Express/JSON-file server) and documents non-obvious setup details for future Cloud agents.

- Installed dependencies for both `server` and `client` and configured an idempotent startup update script (`npm install --prefix server` / `npm install --prefix client`).
- Ran both services in development mode and validated the app end to end.
- Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` capturing durable, non-obvious gotchas (JSON-file DB, hardcoded `http://localhost:5000` API base, `--openssl-legacy-provider` requirement on Node 22, seeded `admin`/`admin` account, vendored `node_modules`, stray `client/client` folder).

No application code was changed.

## Services verified

| Service | Command | Port | Result |
| --- | --- | --- | --- |
| Server (Express) | `npm run dev --prefix server` | 5000 | Running; `/api/login`, `/api/vaccination-schedule`, `/api/news` return 200 |
| Client (React/CRA) | `npm start --prefix client` | 3000 | Compiled successfully; serves 200 |

## Hello-world E2E test

Logged in as `admin`/`admin`, opened the dashboard and My Children list, then created a new child via the add-child form (Persian/Jalali date picker) and confirmed it appears in the list.

[roshdyar_login_and_add_child_demo.mp4](https://cursor.com/agents/bc-52a42649-1fb6-431c-9e6c-d39cdf5829fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Froshdyar_login_and_add_child_demo.mp4)

[Login page](https://cursor.com/agents/bc-52a42649-1fb6-431c-9e6c-d39cdf5829fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Froshdyar_login.webp)
[Dashboard after login](https://cursor.com/agents/bc-52a42649-1fb6-431c-9e6c-d39cdf5829fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Froshdyar_dashboard.webp)
[My Children list with newly added child](https://cursor.com/agents/bc-52a42649-1fb6-431c-9e6c-d39cdf5829fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Froshdyar_children_after_add.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52a42649-1fb6-431c-9e6c-d39cdf5829fb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52a42649-1fb6-431c-9e6c-d39cdf5829fb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

