### PR TITLE
Fix Amin login, content homepage, and SMS OTP login flow

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -27,17 +27,6 @@ import MobileBottomNav from './components/MobileBottomNav';
 import './App.css';
 
 const App = () => {
-    const isLoggedIn = () => {
-        try {
-            const loggedInUser = localStorage.getItem('loggedInUser');
-            if (!loggedInUser) return false;
-            const user = JSON.parse(loggedInUser);
-            return !!(user && user.id);
-        } catch (error) {
-            return false;
-        }
-    };
-
     return (
         <Router>
             <Switch>
@@ -63,8 +52,9 @@ const App = () => {
                 <Route path="/news/:id" component={ArticleDetailPage} />
                 <AdminRoute path="/admin" component={AdminPage} />
 
+                {/* Public home = content magazine; auth happens when user takes an action */}
                 <Route path="/">
-                    <Redirect to={isLoggedIn() ? "/dashboard" : "/login"} />
+                    <Redirect to="/news" />
                 </Route>
             </Switch>
             <MobileBottomNav />

--- a/client/src/components/AddChildPage.js
+++ b/client/src/components/AddChildPage.js
@@ -138,7 +138,7 @@ const AddChildPage = () => {
             const loggedInUser = JSON.parse(localStorage.getItem('loggedInUser'));
             if (!loggedInUser || !loggedInUser.id) {
                 alert('لطفا برای افزودن کودک ابتدا وارد شوید.');
-                history.push('/login');
+                history.push('/register');
                 return;
             }
 

--- a/client/src/components/CartPage.js
+++ b/client/src/components/CartPage.js
@@ -56,7 +56,7 @@ const CartPage = () => {
 
         if (!user || !user.id) {
             alert('برای ثبت سفارش ابتدا وارد شوید.');
-            history.push('/login');
+            history.push('/register');
             return;
         }
 

--- a/client/src/components/EditChildPage.js
+++ b/client/src/components/EditChildPage.js
@@ -165,7 +165,7 @@ const EditChildPage = () => {
             const loggedInUser = JSON.parse(localStorage.getItem('loggedInUser'));
             if (!loggedInUser || !loggedInUser.id) {
                 alert('برای انجام این عملیات باید وارد شده باشید.');
-                history.push('/login');
+                history.push('/register');
                 return;
             }
 

--- a/client/src/components/Footer.js
+++ b/client/src/components/Footer.js
@@ -19,10 +19,10 @@ const Footer = () => {
                 <div className="footer-section">
                     <h4>دسترسی سریع</h4>
                     <ul>
-                        <li><a href="/dashboard">داشبورد</a></li>
-                        <li><a href="/my-children">فرزندان من</a></li>
-                        <li><a href="/shop">فروشگاه</a></li>
                         <li><a href="/news">مجله سلامت</a></li>
+                        <li><a href="/register">ورود / ثبت‌نام</a></li>
+                        <li><a href="/dashboard">داشبورد</a></li>
+                        <li><a href="/shop">فروشگاه</a></li>
                     </ul>
                 </div>
                 <div className="footer-section">

--- a/client/src/components/LoginPage.js
+++ b/client/src/components/LoginPage.js
@@ -69,19 +69,19 @@ const LoginPage = () => {
             <section className="login-panel">
                 <div className="login-card animate-fade-up">
                     <div className="login-card-header">
-                        <h2>ورود به حساب</h2>
-                        <p>برای ادامه، وارد شوید یا حساب جدید بسازید.</p>
+                        <h2>ورود با رمز عبور</h2>
+                        <p>برای ورود والدین، از ورود پیامکی استفاده کنید. این صفحه برای مدیران است.</p>
                     </div>
 
                     <div className="login-field">
-                        <label htmlFor="login-input">ایمیل یا شماره موبایل</label>
+                        <label htmlFor="login-input">نام کاربری</label>
                         <input
                             id="login-input"
                             type="text"
                             value={loginInput}
                             onChange={(e) => setLoginInput(e.target.value)}
                             onKeyDown={handleKeyDown}
-                            placeholder="مثال: ۰۹۱۲xxxxxxx"
+                            placeholder="مثال: Amin"
                             autoComplete="username"
                         />
                     </div>
@@ -104,7 +104,7 @@ const LoginPage = () => {
                             ورود
                         </button>
                         <button type="button" className="login-btn login-btn-secondary" onClick={handleSignup}>
-                            ثبت‌نام
+                            ورود / ثبت‌نام با پیامک
                         </button>
                     </div>
 

--- a/client/src/components/MobileBottomNav.js
+++ b/client/src/components/MobileBottomNav.js
@@ -28,7 +28,9 @@ const MobileBottomNav = () => {
     useEffect(() => {
         const hide =
             location.pathname.startsWith('/login') ||
-            location.pathname.startsWith('/admin');
+            location.pathname.startsWith('/register') ||
+            location.pathname.startsWith('/admin') ||
+            location.pathname.startsWith('/news');
         if (hide) {
             document.body.classList.remove('has-mobile-bottom-nav');
             return undefined;
@@ -37,7 +39,12 @@ const MobileBottomNav = () => {
         return () => document.body.classList.remove('has-mobile-bottom-nav');
     }, [location.pathname]);
 
-    if (location.pathname.startsWith('/login') || location.pathname.startsWith('/admin')) {
+    if (
+        location.pathname.startsWith('/login') ||
+        location.pathname.startsWith('/register') ||
+        location.pathname.startsWith('/admin') ||
+        location.pathname.startsWith('/news')
+    ) {
         return null;
     }
 

--- a/client/src/components/MyChildrenPage.js
+++ b/client/src/components/MyChildrenPage.js
@@ -12,7 +12,7 @@ const MyChildrenPage = () => {
             if (!loggedInUser) {
                 console.error("No user logged in.");
                 // Optionally redirect to login
-                history.push('/login');
+                history.push('/register');
                 return;
             }
 

--- a/client/src/components/NewsHeader.css
+++ b/client/src/components/NewsHeader.css
@@ -76,6 +76,34 @@
   cursor: pointer;
 }
 
+.news-login-cta {
+  color: #fff !important;
+  text-decoration: none;
+  font-weight: 700;
+  font-size: 0.9rem;
+  padding: 0.45rem 0.95rem;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.12);
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+  white-space: nowrap;
+}
+
+.news-login-cta:hover {
+  background: rgba(255, 255, 255, 0.22);
+  border-color: rgba(255, 255, 255, 0.55);
+  color: #fff !important;
+}
+
+.news-navbar .navbar-links .news-login-cta {
+  display: none;
+}
+
+.news-login-cta--desktop {
+  display: inline-flex;
+  align-items: center;
+}
+
 .news-navbar + .menu-backdrop,
 .menu-backdrop {
   position: fixed;
@@ -120,5 +148,15 @@
 
   .news-navbar .navbar-toggler {
     display: block;
+  }
+
+  .news-login-cta--desktop {
+    display: none;
+  }
+
+  .news-navbar .navbar-links .news-login-cta {
+    display: block;
+    text-align: center;
+    margin-top: 0.75rem;
   }
 }

--- a/client/src/components/NewsHeader.js
+++ b/client/src/components/NewsHeader.js
@@ -9,6 +9,17 @@ const NewsHeader = () => {
         setIsMenuOpen(!isMenuOpen);
     };
 
+    const isLoggedIn = (() => {
+        try {
+            const raw = localStorage.getItem('loggedInUser');
+            if (!raw) return false;
+            const user = JSON.parse(raw);
+            return !!(user && user.id);
+        } catch {
+            return false;
+        }
+    })();
+
     return (
         <>
             <nav className="news-navbar">
@@ -26,10 +37,29 @@ const NewsHeader = () => {
                         <Link to={{ pathname: "/news", state: { category: 'تغذیه' } }} onClick={() => setIsMenuOpen(false)}>تغذیه</Link>
                         <Link to={{ pathname: "/news", state: { category: 'مادر و کودک' } }} onClick={() => setIsMenuOpen(false)}>مادر و کودک</Link>
                         <Link to={{ pathname: "/news", state: { category: 'تربیتی' } }} onClick={() => setIsMenuOpen(false)}>تربیتی</Link>
+                        {isLoggedIn ? (
+                            <Link to="/dashboard" className="news-login-cta" onClick={() => setIsMenuOpen(false)}>
+                                داشبورد
+                            </Link>
+                        ) : (
+                            <Link to="/register" className="news-login-cta" onClick={() => setIsMenuOpen(false)}>
+                                ورود / ثبت‌نام
+                            </Link>
+                        )}
                     </div>
                 </div>
 
                 <div className="navbar-right">
+                    {!isLoggedIn && (
+                        <Link to="/register" className="news-login-cta news-login-cta--desktop">
+                            ورود
+                        </Link>
+                    )}
+                    {isLoggedIn && (
+                        <Link to="/dashboard" className="news-login-cta news-login-cta--desktop">
+                            داشبورد
+                        </Link>
+                    )}
                     <button
                         className="navbar-toggler"
                         type="button"

--- a/client/src/components/OrdersPage.js
+++ b/client/src/components/OrdersPage.js
@@ -34,7 +34,7 @@ const OrdersPage = () => {
         })();
 
         if (!user || !user.id) {
-            history.push('/login');
+            history.push('/register');
             return;
         }
 

--- a/client/src/components/PrivateRoute.js
+++ b/client/src/components/PrivateRoute.js
@@ -20,7 +20,7 @@ const PrivateRoute = ({ component: Component, ...rest }) => {
                 isLoggedIn() ? (
                     <Component {...props} />
                 ) : (
-                    <Redirect to="/login" />
+                    <Redirect to="/register" />
                 )
             }
         />

--- a/client/src/components/ProfilePage.js
+++ b/client/src/components/ProfilePage.js
@@ -14,7 +14,7 @@ const ProfilePage = () => {
 
     const handleLogout = () => {
         localStorage.removeItem('loggedInUser');
-        history.push('/login');
+        history.push('/news');
     };
 
     const handleGenerateReminders = async () => {

--- a/client/src/components/RegisterPage.js
+++ b/client/src/components/RegisterPage.js
@@ -44,6 +44,7 @@ const RegisterPage = () => {
     const [secondsLeft, setSecondsLeft] = useState(0);
     const [showWelcome, setShowWelcome] = useState(false);
     const [devHint, setDevHint] = useState('');
+    const [isNewUser, setIsNewUser] = useState(false);
     const expiresAtRef = useRef(null);
 
     useEffect(() => {
@@ -137,7 +138,12 @@ const RegisterPage = () => {
             }
 
             localStorage.setItem('loggedInUser', JSON.stringify(data.user));
-            setShowWelcome(true);
+            if (data.isNewUser) {
+                setIsNewUser(true);
+                setShowWelcome(true);
+            } else {
+                history.push('/dashboard');
+            }
         } catch (error) {
             showError('خطا در ارتباط با سرور.');
         } finally {
@@ -165,9 +171,9 @@ const RegisterPage = () => {
                             <p className="brand-name-en">TatKids</p>
                         </div>
                     </div>
-                    <h1 className="animate-fade-up-delay">ثبت‌نام سریع با موبایل</h1>
+                    <h1 className="animate-fade-up-delay">ورود و ثبت‌نام با موبایل</h1>
                     <p className="animate-fade-up-delay-2">
-                        شماره را وارد کنید، کد تأیید بگیرید و پروفایل کودک‌تان را بسازید.
+                        شماره را وارد کنید، کد پیامکی بگیرید و وارد شوید.
                     </p>
                 </div>
             </section>
@@ -175,7 +181,7 @@ const RegisterPage = () => {
             <section className="login-panel">
                 <div className="login-card animate-fade-up">
                     <div className="login-card-header">
-                        <h2>{step === 'phone' ? 'ثبت‌نام' : 'کد تأیید'}</h2>
+                        <h2>{step === 'phone' ? 'ورود / ثبت‌نام' : 'کد تأیید'}</h2>
                         <p>
                             {step === 'phone'
                                 ? 'شماره موبایل خود را وارد کنید تا کد تأیید برایتان ارسال شود.'
@@ -209,8 +215,11 @@ const RegisterPage = () => {
                                 >
                                     {loading ? 'در حال ارسال...' : 'ارسال کد تأیید'}
                                 </button>
-                                <Link to="/login" className="login-btn login-btn-secondary register-link-btn">
-                                    بازگشت به ورود
+                                <Link to="/news" className="login-btn login-btn-secondary register-link-btn">
+                                    بازگشت به مجله
+                                </Link>
+                                <Link to="/login" className="register-text-btn">
+                                    ورود مدیران با رمز عبور
                                 </Link>
                             </div>
                         </>
@@ -253,7 +262,7 @@ const RegisterPage = () => {
                                     onClick={handleVerifyOtp}
                                     disabled={loading || secondsLeft <= 0}
                                 >
-                                    {loading ? 'در حال بررسی...' : 'تأیید و ثبت‌نام'}
+                                    {loading ? 'در حال بررسی...' : 'تأیید و ورود'}
                                 </button>
                                 <button
                                     type="button"
@@ -295,7 +304,11 @@ const RegisterPage = () => {
                 <div className="welcome-modal-body">
                     <BrandLogo className="welcome-modal-logo" size={56} alt="" />
                     <h2>به تات کیدز خوش آمدید</h2>
-                    <p>حساب شما ساخته شد. برای شروع بهتر، پروفایل کاربری‌تان را تکمیل کنید.</p>
+                    <p>
+                        {isNewUser
+                            ? 'حساب شما ساخته شد. برای شروع بهتر، پروفایل کاربری‌تان را تکمیل کنید.'
+                            : 'ورود شما موفقیت‌آمیز بود.'}
+                    </p>
                     <button type="button" className="login-btn login-btn-primary" onClick={goToCompleteProfile}>
                         تکمیل پروفایل کاربری
                     </button>

--- a/client/src/components/ServiceTiles.js
+++ b/client/src/components/ServiceTiles.js
@@ -44,7 +44,7 @@ const ServiceTiles = () => {
 
             if (!userId) {
                 alert('لطفا برای مشاهده این بخش ابتدا وارد شوید.');
-                history.push('/login');
+                history.push('/register');
                 return;
             }
 

--- a/server/db.js
+++ b/server/db.js
@@ -99,6 +99,19 @@ function loadState() {
     connect();
     const row = db.prepare('SELECT data FROM app_state WHERE id = ?').get('main');
     if (!row) {
+        // Seed from db.json on first boot so default admin (Amin) and sample data exist.
+        const jsonPath = path.join(__dirname, 'db.json');
+        if (fs.existsSync(jsonPath)) {
+            try {
+                const raw = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+                const seeded = normalizeState(raw);
+                saveState(seeded);
+                console.log(`Seeded SQLite from ${jsonPath}`);
+                return seeded;
+            } catch (err) {
+                console.error('Failed to seed from db.json:', err.message);
+            }
+        }
         const state = emptyState();
         saveState(state);
         return state;

--- a/server/db.json
+++ b/server/db.json
@@ -2,7 +2,7 @@
   "users": {
     "1": {
       "id": 1,
-      "username": "admin",
+      "username": "Amin",
       "email": "admin@example.com",
       "password": "admin",
       "isAdmin": true

--- a/server/server.js
+++ b/server/server.js
@@ -156,6 +156,58 @@ function findUserByPhone(phone) {
     );
 }
 
+/** Admin accounts accept both "Amin" and "admin" as login aliases. */
+const ADMIN_LOGIN_ALIASES = new Set(['amin', 'admin']);
+
+function identitiesMatch(user, login) {
+    const loginRaw = String(login || '').trim();
+    if (!loginRaw) return false;
+
+    const loginLower = loginRaw.toLowerCase();
+    const usernameLower = String(user.username || '').toLowerCase();
+    const emailLower = String(user.email || '').toLowerCase();
+    const normalizedLogin = normalizePhone(loginRaw);
+
+    const adminAliasMatch =
+        user.isAdmin &&
+        ADMIN_LOGIN_ALIASES.has(loginLower) &&
+        ADMIN_LOGIN_ALIASES.has(usernameLower);
+
+    return (
+        usernameLower === loginLower ||
+        emailLower === loginLower ||
+        adminAliasMatch ||
+        (normalizedLogin &&
+            (normalizePhone(user.mobile) === normalizedLogin ||
+                normalizePhone(user.username) === normalizedLogin))
+    );
+}
+
+function ensureDefaultAdmin() {
+    const existingAdmin = Object.values(users).find((u) => u.isAdmin);
+    if (existingAdmin) {
+        // Normalize legacy "admin" username to "Amin" (login still accepts both).
+        if (String(existingAdmin.username || '').toLowerCase() === 'admin') {
+            existingAdmin.username = 'Amin';
+            users[String(existingAdmin.id)] = existingAdmin;
+            saveData();
+            console.log('Renamed legacy admin username to Amin');
+        }
+        return;
+    }
+
+    const newId = userIdCounter++;
+    users[String(newId)] = {
+        id: newId,
+        username: 'Amin',
+        email: 'admin@example.com',
+        password: 'admin',
+        isAdmin: true
+    };
+    saveData();
+    console.log('Created default admin user: Amin / admin');
+}
+
 function publicUser(user) {
     const { password, ...userToSend } = user;
     return userToSend;
@@ -277,15 +329,12 @@ async function deliverOtp(phone, code) {
 // --- Auth Routes ---
 app.post('/api/login', (req, res) => {
     const { login, password } = req.body;
-    const normalizedLogin = normalizePhone(login);
-    const user = Object.values(users).find((u) => {
-        const matchesIdentity =
-            u.username === login ||
-            u.email === login ||
-            normalizePhone(u.mobile) === normalizedLogin ||
-            normalizePhone(u.username) === normalizedLogin;
-        return matchesIdentity && u.password === password;
-    });
+    if (!login || !password) {
+        return res.status(400).json({ message: 'نام کاربری و رمز عبور الزامی است' });
+    }
+    const user = Object.values(users).find(
+        (u) => identitiesMatch(u, login) && u.password != null && u.password === password
+    );
     if (user) {
         res.status(200).json({ message: 'ورود موفقیت‌آمیز', user: publicUser(user) });
     } else {
@@ -313,10 +362,7 @@ app.post('/api/auth/send-otp', async (req, res) => {
         return res.status(400).json({ message: 'شماره موبایل معتبر نیست. مثال: ۰۹۱۲xxxxxxx' });
     }
 
-    if (findUserByPhone(phone)) {
-        return res.status(409).json({ message: 'این شماره قبلاً ثبت شده است. وارد شوید.' });
-    }
-
+    // OTP is used for both login and registration — do not block existing phones.
     const existing = otpStore.get(phone);
     const now = Date.now();
     if (existing && now - existing.sentAt < OTP_RESEND_COOLDOWN_MS) {
@@ -1721,6 +1767,7 @@ async function startServer() {
         connect();
         const state = loadState();
         applyState(state);
+        ensureDefaultAdmin();
         app.listen(port, () => console.log(`TatKids server is listening on port ${port}`));
     } catch (err) {
         console.error('Failed to start server with SQLite:', err);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## مشکل‌ها
1. ورود با **Amin** ممکن نبود (کاربر پیش‌فرض `admin` بود و در SQLite خالی ممکن بود اصلاً ادمین وجود نداشته باشد).
2. ورود به `tatkids.com/` مستقیم به داشبورد/لاگین می‌رفت؛ باید اول **صفحه محتوا (مجله)** باز شود و وقتی کاربر بخواهد کاری کند به **ورود پیامکی** برود. OTP برای شماره‌های قبلی هم گیر می‌کرد.

## تغییرات
- کاربر ادمین پیش‌فرض: **Amin / admin** (هر دو `Amin` و `admin` پذیرفته می‌شوند)
- Seed خودکار از `db.json` در اولین بوت SQLite + `ensureDefaultAdmin`
- مسیر `/` → `/news` (صفحه محتوا)
- مسیرهای محافظت‌شده و اکشن‌های نیازمند لاگین → `/register` (ورود/ثبت‌نام پیامکی)
- `send-otp` دیگر شماره‌های ثبت‌شده را بلاک نمی‌کند (ورود و ثبت‌نام با همان OTP)
- دکمه ورود در هدر مجله

## تست دستی (همه پاس)
[Home opens news magazine](https://cursor.com/agents/bc-e5f8eab2-0b36-4ca1-a8ff-0d04f3b53666/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F01-home-news.webp)
[SMS login page](https://cursor.com/agents/bc-e5f8eab2-0b36-4ca1-a8ff-0d04f3b53666/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F02-sms-login.webp)
[Amin login reaches dashboard](https://cursor.com/agents/bc-e5f8eab2-0b36-4ca1-a8ff-0d04f3b53666/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F03-amin-dashboard.webp)
[Protected route redirects to SMS](https://cursor.com/agents/bc-e5f8eab2-0b36-4ca1-a8ff-0d04f3b53666/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F04-protected-to-sms.webp)

- `/` → مجله محتوا
- دکمه ورود → صفحه SMS (`/register`)
- ورود `Amin` / `admin` → داشبورد
- بدون لاگین، `/dashboard` → `/register`
- ارسال OTP برای شماره قبلی دیگر 409 نمی‌دهد

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5f8eab2-0b36-4ca1-a8ff-0d04f3b53666?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5f8eab2-0b36-4ca1-a8ff-0d04f3b53666&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

