### PR TITLE
Fix OTP SMS cooldown, forgot-password flow, hide admin login

### DIFF
--- a/client/src/components/LoginPage.js
+++ b/client/src/components/LoginPage.js
@@ -1,21 +1,87 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import BrandLogo from './BrandLogo';
 import './LoginPage.css';
+import './RegisterPage.css';
+
+const OTP_TTL_SEC = 5 * 60;
+const OTP_RESEND_COOLDOWN_SEC = 60;
+const API_BASE = '';
+
+const toEnglishDigits = (value) =>
+    String(value || '')
+        .replace(/[۰-۹]/g, (d) => '۰۱۲۳۴۵۶۷۸۹'.indexOf(d))
+        .replace(/[٠-٩]/g, (d) => '٠١٢٣٤٥٦٧٨٩'.indexOf(d));
+
+const normalizePhone = (phone) => {
+    let p = toEnglishDigits(phone).replace(/[\s\-_().]/g, '');
+    if (p.startsWith('+98')) p = `0${p.slice(3)}`;
+    else if (p.startsWith('0098')) p = `0${p.slice(4)}`;
+    else if (p.startsWith('98') && p.length === 12) p = `0${p.slice(2)}`;
+    return p;
+};
+
+const isValidIranMobile = (phone) => /^09\d{9}$/.test(phone);
+
+const formatTimer = (totalSec) => {
+    const m = Math.floor(totalSec / 60);
+    const s = totalSec % 60;
+    return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+};
 
 const LoginPage = () => {
     const history = useHistory();
+    const [mode, setMode] = useState('login'); // login | forgot-phone | forgot-otp | forgot-password
     const [loginInput, setLoginInput] = useState('');
     const [passwordInput, setPasswordInput] = useState('');
+    const [phoneInput, setPhoneInput] = useState('');
+    const [otpInput, setOtpInput] = useState('');
+    const [newPassword, setNewPassword] = useState('');
+    const [confirmPassword, setConfirmPassword] = useState('');
     const [loginMessage, setLoginMessage] = useState('');
     const [messageType, setMessageType] = useState('error');
+    const [loading, setLoading] = useState(false);
+    const [secondsLeft, setSecondsLeft] = useState(0);
+    const [resendCooldown, setResendCooldown] = useState(0);
+    const [devHint, setDevHint] = useState('');
+    const expiresAtRef = useRef(null);
+    const resendUntilRef = useRef(null);
+    const sendingRef = useRef(false);
+
+    useEffect(() => {
+        if (mode !== 'forgot-otp' && mode !== 'forgot-password') return undefined;
+        if (!expiresAtRef.current) return undefined;
+
+        const tick = () => {
+            const left = Math.max(0, Math.ceil((expiresAtRef.current - Date.now()) / 1000));
+            setSecondsLeft(left);
+            if (resendUntilRef.current) {
+                setResendCooldown(Math.max(0, Math.ceil((resendUntilRef.current - Date.now()) / 1000)));
+            }
+        };
+
+        tick();
+        const id = setInterval(tick, 1000);
+        return () => clearInterval(id);
+    }, [mode]);
+
+    const showError = (text) => {
+        setMessageType('error');
+        setLoginMessage(text);
+    };
+
+    const showSuccess = (text) => {
+        setMessageType('success');
+        setLoginMessage(text);
+    };
 
     const handleLogin = async () => {
         if (!loginInput || !passwordInput) {
-            setMessageType('error');
-            setLoginMessage('لطفاً فیلدها را پر کنید.');
+            showError('لطفاً فیلدها را پر کنید.');
             return;
         }
+        setLoading(true);
+        setLoginMessage('');
         try {
             const response = await fetch('/api/login', {
                 method: 'POST',
@@ -29,23 +95,208 @@ const LoginPage = () => {
                 localStorage.setItem('loggedInUser', JSON.stringify(data.user));
                 history.push('/dashboard');
             } else {
-                setMessageType('error');
-                setLoginMessage(data.message || 'اطلاعات ورود نادرست است.');
+                showError(data.message || 'اطلاعات ورود نادرست است.');
             }
         } catch (error) {
-            setMessageType('error');
-            setLoginMessage('خطا در ارتباط با سرور.');
+            showError('خطا در ارتباط با سرور.');
+        } finally {
+            setLoading(false);
         }
     };
 
-    const handleSignup = () => {
-        history.push('/register');
+    const enterForgotOtpStep = (phone, data, { alreadySent = false } = {}) => {
+        setPhoneInput(phone);
+        expiresAtRef.current = data.expiresAt
+            ? new Date(data.expiresAt).getTime()
+            : Date.now() + (data.expiresInSec || OTP_TTL_SEC) * 1000;
+        setSecondsLeft(
+            data.expiresInSec != null
+                ? data.expiresInSec
+                : Math.max(0, Math.ceil((expiresAtRef.current - Date.now()) / 1000))
+        );
+        const cooldownSec = data.retryAfterSec != null ? data.retryAfterSec : OTP_RESEND_COOLDOWN_SEC;
+        resendUntilRef.current = Date.now() + cooldownSec * 1000;
+        setResendCooldown(cooldownSec);
+        setOtpInput('');
+        setMode('forgot-otp');
+        if (alreadySent) {
+            showError(data.message || 'کد قبلاً ارسال شده است. همان کد را وارد کنید.');
+        } else {
+            showSuccess('کد تأیید ارسال شد.');
+        }
+        if (data.devOtp) {
+            setDevHint(`کد آزمایشی: ${data.devOtp}`);
+        }
     };
 
-    const handleKeyDown = (e) => {
-        if (e.key === 'Enter') {
-            handleLogin();
+    const handleSendForgotOtp = async () => {
+        const phone = normalizePhone(phoneInput);
+        if (!isValidIranMobile(phone)) {
+            showError('شماره موبایل معتبر نیست. مثال: ۰۹۱۲xxxxxxx');
+            return;
         }
+        if (sendingRef.current) return;
+
+        sendingRef.current = true;
+        setLoading(true);
+        setLoginMessage('');
+        setDevHint('');
+        try {
+            const response = await fetch(`${API_BASE}/api/auth/forgot-password/send-otp`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ phone }),
+            });
+            const data = await response.json();
+
+            if (response.status === 429 && (data.codeAlreadySent || data.expiresAt || data.expiresInSec)) {
+                enterForgotOtpStep(phone, data, { alreadySent: true });
+                return;
+            }
+
+            if (!response.ok) {
+                showError(data.message || 'ارسال کد ناموفق بود.');
+                return;
+            }
+
+            enterForgotOtpStep(phone, data);
+        } catch (error) {
+            showError('خطا در ارتباط با سرور.');
+        } finally {
+            sendingRef.current = false;
+            setLoading(false);
+        }
+    };
+
+    const handleVerifyForgotOtp = async () => {
+        const phone = normalizePhone(phoneInput);
+        const code = toEnglishDigits(otpInput).replace(/\D/g, '');
+        if (secondsLeft <= 0) {
+            showError('کد تأیید منقضی شده است. دوباره درخواست کنید.');
+            return;
+        }
+        if (!/^\d{5}$/.test(code)) {
+            showError('کد تأیید باید ۵ رقم باشد.');
+            return;
+        }
+
+        setLoading(true);
+        setLoginMessage('');
+        try {
+            const response = await fetch(`${API_BASE}/api/auth/forgot-password/verify-otp`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ phone, code }),
+            });
+            const data = await response.json();
+            if (!response.ok) {
+                showError(data.message || 'اعتبارسنجی کد ناموفق بود.');
+                return;
+            }
+
+            setOtpInput(code);
+            if (data.expiresAt) {
+                expiresAtRef.current = new Date(data.expiresAt).getTime();
+                setSecondsLeft(
+                    data.expiresInSec != null
+                        ? data.expiresInSec
+                        : Math.max(0, Math.ceil((expiresAtRef.current - Date.now()) / 1000))
+                );
+            }
+            setMode('forgot-password');
+            showSuccess('کد پذیرفته شد. رمز عبور جدید را وارد کنید.');
+        } catch (error) {
+            showError('خطا در ارتباط با سرور.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleResetPassword = async () => {
+        const phone = normalizePhone(phoneInput);
+        const code = toEnglishDigits(otpInput).replace(/\D/g, '');
+
+        if (secondsLeft <= 0) {
+            showError('کد تأیید منقضی شده است. دوباره از ابتدا درخواست کنید.');
+            setMode('forgot-phone');
+            return;
+        }
+        if (!/^\d{5}$/.test(code)) {
+            showError('کد تأیید باید ۵ رقم باشد.');
+            setMode('forgot-otp');
+            return;
+        }
+        if (!newPassword || newPassword.length < 4) {
+            showError('رمز عبور باید حداقل ۴ کاراکتر باشد.');
+            return;
+        }
+        if (newPassword !== confirmPassword) {
+            showError('رمز عبور و تکرار آن یکسان نیستند.');
+            return;
+        }
+
+        setLoading(true);
+        setLoginMessage('');
+        try {
+            const response = await fetch(`${API_BASE}/api/auth/forgot-password/reset`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ phone, code, newPassword }),
+            });
+            const data = await response.json();
+            if (!response.ok) {
+                showError(data.message || 'ثبت رمز عبور ناموفق بود.');
+                if (response.status === 401 || response.status === 410 || response.status === 400) {
+                    setMode('forgot-otp');
+                }
+                return;
+            }
+
+            setLoginInput(phone);
+            setPasswordInput('');
+            setNewPassword('');
+            setConfirmPassword('');
+            setOtpInput('');
+            setDevHint('');
+            setMode('login');
+            showSuccess(data.message || 'رمز عبور ثبت شد. اکنون وارد شوید.');
+        } catch (error) {
+            showError('خطا در ارتباط با سرور.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const resetForgotFlow = () => {
+        setMode('login');
+        setPhoneInput('');
+        setOtpInput('');
+        setNewPassword('');
+        setConfirmPassword('');
+        setDevHint('');
+        setSecondsLeft(0);
+        setResendCooldown(0);
+        setLoginMessage('');
+        expiresAtRef.current = null;
+        resendUntilRef.current = null;
+    };
+
+    const handleKeyDown = (e, action) => {
+        if (e.key === 'Enter') action();
+    };
+
+    const titleByMode = {
+        login: 'ورود با رمز عبور',
+        'forgot-phone': 'فراموشی / تنظیم رمز عبور',
+        'forgot-otp': 'کد تأیید',
+        'forgot-password': 'ثبت رمز عبور جدید',
+    };
+
+    const subtitleByMode = {
+        login: 'اگر قبلاً رمز عبور ثبت کرده‌اید وارد شوید؛ در غیر این صورت از ورود پیامکی استفاده کنید.',
+        'forgot-phone': 'شماره‌ای که با آن ثبت‌نام کرده‌اید را وارد کنید تا کد تأیید برایتان ارسال شود.',
+        'forgot-otp': `کد ۵ رقمی ارسال‌شده به ${phoneInput} را وارد کنید.`,
+        'forgot-password': 'رمز عبور جدید را برای حساب خود تعیین کنید.',
     };
 
     return (
@@ -69,44 +320,234 @@ const LoginPage = () => {
             <section className="login-panel">
                 <div className="login-card animate-fade-up">
                     <div className="login-card-header">
-                        <h2>ورود با رمز عبور</h2>
-                        <p>برای ورود والدین، از ورود پیامکی استفاده کنید. این صفحه برای مدیران است.</p>
+                        <h2>{titleByMode[mode]}</h2>
+                        <p>{subtitleByMode[mode]}</p>
                     </div>
 
-                    <div className="login-field">
-                        <label htmlFor="login-input">نام کاربری</label>
-                        <input
-                            id="login-input"
-                            type="text"
-                            value={loginInput}
-                            onChange={(e) => setLoginInput(e.target.value)}
-                            onKeyDown={handleKeyDown}
-                            placeholder="مثال: Amin"
-                            autoComplete="username"
-                        />
-                    </div>
+                    {mode === 'login' && (
+                        <>
+                            <div className="login-field">
+                                <label htmlFor="login-input">نام کاربری یا موبایل</label>
+                                <input
+                                    id="login-input"
+                                    type="text"
+                                    value={loginInput}
+                                    onChange={(e) => setLoginInput(e.target.value)}
+                                    onKeyDown={(e) => handleKeyDown(e, handleLogin)}
+                                    placeholder="مثال: ۰۹۱۲xxxxxxx"
+                                    autoComplete="username"
+                                    disabled={loading}
+                                />
+                            </div>
 
-                    <div className="login-field">
-                        <label htmlFor="password-input">رمز عبور</label>
-                        <input
-                            id="password-input"
-                            type="password"
-                            value={passwordInput}
-                            onChange={(e) => setPasswordInput(e.target.value)}
-                            onKeyDown={handleKeyDown}
-                            placeholder="رمز عبور خود را وارد کنید"
-                            autoComplete="current-password"
-                        />
-                    </div>
+                            <div className="login-field">
+                                <label htmlFor="password-input">رمز عبور</label>
+                                <input
+                                    id="password-input"
+                                    type="password"
+                                    value={passwordInput}
+                                    onChange={(e) => setPasswordInput(e.target.value)}
+                                    onKeyDown={(e) => handleKeyDown(e, handleLogin)}
+                                    placeholder="رمز عبور خود را وارد کنید"
+                                    autoComplete="current-password"
+                                    disabled={loading}
+                                />
+                            </div>
 
-                    <div className="login-actions">
-                        <button type="button" className="login-btn login-btn-primary" onClick={handleLogin}>
-                            ورود
-                        </button>
-                        <button type="button" className="login-btn login-btn-secondary" onClick={handleSignup}>
-                            ورود / ثبت‌نام با پیامک
-                        </button>
-                    </div>
+                            <div className="login-actions">
+                                <button
+                                    type="button"
+                                    className="login-btn login-btn-primary"
+                                    onClick={handleLogin}
+                                    disabled={loading}
+                                >
+                                    {loading ? 'در حال ورود...' : 'ورود'}
+                                </button>
+                                <button
+                                    type="button"
+                                    className="login-btn login-btn-secondary"
+                                    onClick={() => history.push('/register')}
+                                    disabled={loading}
+                                >
+                                    ورود / ثبت‌نام با پیامک
+                                </button>
+                                <button
+                                    type="button"
+                                    className="register-text-btn"
+                                    onClick={() => {
+                                        setMode('forgot-phone');
+                                        setLoginMessage('');
+                                        setDevHint('');
+                                    }}
+                                    disabled={loading}
+                                >
+                                    فراموشی رمز عبور / تنظیم رمز
+                                </button>
+                            </div>
+                        </>
+                    )}
+
+                    {mode === 'forgot-phone' && (
+                        <>
+                            <div className="login-field">
+                                <label htmlFor="forgot-phone">شماره موبایل</label>
+                                <input
+                                    id="forgot-phone"
+                                    type="tel"
+                                    inputMode="numeric"
+                                    value={phoneInput}
+                                    onChange={(e) => setPhoneInput(e.target.value)}
+                                    onKeyDown={(e) => handleKeyDown(e, handleSendForgotOtp)}
+                                    placeholder="۰۹۱۲xxxxxxx"
+                                    autoComplete="tel"
+                                    disabled={loading}
+                                />
+                            </div>
+
+                            <div className="login-actions">
+                                <button
+                                    type="button"
+                                    className="login-btn login-btn-primary"
+                                    onClick={handleSendForgotOtp}
+                                    disabled={loading}
+                                >
+                                    {loading ? 'در حال ارسال...' : 'ارسال کد تأیید'}
+                                </button>
+                                <button
+                                    type="button"
+                                    className="register-text-btn"
+                                    onClick={resetForgotFlow}
+                                    disabled={loading}
+                                >
+                                    بازگشت به ورود
+                                </button>
+                            </div>
+                        </>
+                    )}
+
+                    {mode === 'forgot-otp' && (
+                        <>
+                            <div className="login-field">
+                                <label htmlFor="forgot-otp">کد تأیید</label>
+                                <input
+                                    id="forgot-otp"
+                                    type="text"
+                                    inputMode="numeric"
+                                    maxLength={5}
+                                    value={otpInput}
+                                    onChange={(e) =>
+                                        setOtpInput(toEnglishDigits(e.target.value).replace(/\D/g, '').slice(0, 5))
+                                    }
+                                    onKeyDown={(e) => handleKeyDown(e, handleVerifyForgotOtp)}
+                                    placeholder="•••••"
+                                    autoComplete="one-time-code"
+                                    className="otp-input"
+                                    disabled={loading}
+                                />
+                            </div>
+
+                            <div className={`otp-timer${secondsLeft <= 0 ? ' is-expired' : ''}`} aria-live="polite">
+                                {secondsLeft > 0 ? (
+                                    <>
+                                        <span className="otp-timer-label">اعتبار کد</span>
+                                        <span className="otp-timer-value">{formatTimer(secondsLeft)}</span>
+                                    </>
+                                ) : (
+                                    <span className="otp-timer-label">کد منقضی شد</span>
+                                )}
+                            </div>
+
+                            {resendCooldown > 0 && (
+                                <p className="otp-resend-hint">ارسال مجدد تا {resendCooldown} ثانیه دیگر</p>
+                            )}
+                            {devHint && <p className="otp-dev-hint">{devHint}</p>}
+
+                            <div className="login-actions">
+                                <button
+                                    type="button"
+                                    className="login-btn login-btn-primary"
+                                    onClick={handleVerifyForgotOtp}
+                                    disabled={loading || secondsLeft <= 0}
+                                >
+                                    ادامه
+                                </button>
+                                <button
+                                    type="button"
+                                    className="login-btn login-btn-secondary"
+                                    onClick={handleSendForgotOtp}
+                                    disabled={loading || resendCooldown > 0}
+                                >
+                                    {resendCooldown > 0 ? `ارسال مجدد (${resendCooldown})` : 'ارسال مجدد کد'}
+                                </button>
+                                <button
+                                    type="button"
+                                    className="register-text-btn"
+                                    onClick={() => {
+                                        setMode('forgot-phone');
+                                        setOtpInput('');
+                                        setLoginMessage('');
+                                        setDevHint('');
+                                    }}
+                                    disabled={loading}
+                                >
+                                    تغییر شماره موبایل
+                                </button>
+                            </div>
+                        </>
+                    )}
+
+                    {mode === 'forgot-password' && (
+                        <>
+                            <div className="login-field">
+                                <label htmlFor="new-password">رمز عبور جدید</label>
+                                <input
+                                    id="new-password"
+                                    type="password"
+                                    value={newPassword}
+                                    onChange={(e) => setNewPassword(e.target.value)}
+                                    onKeyDown={(e) => handleKeyDown(e, handleResetPassword)}
+                                    placeholder="حداقل ۴ کاراکتر"
+                                    autoComplete="new-password"
+                                    disabled={loading}
+                                />
+                            </div>
+                            <div className="login-field">
+                                <label htmlFor="confirm-password">تکرار رمز عبور</label>
+                                <input
+                                    id="confirm-password"
+                                    type="password"
+                                    value={confirmPassword}
+                                    onChange={(e) => setConfirmPassword(e.target.value)}
+                                    onKeyDown={(e) => handleKeyDown(e, handleResetPassword)}
+                                    placeholder="تکرار رمز عبور"
+                                    autoComplete="new-password"
+                                    disabled={loading}
+                                />
+                            </div>
+
+                            <div className="login-actions">
+                                <button
+                                    type="button"
+                                    className="login-btn login-btn-primary"
+                                    onClick={handleResetPassword}
+                                    disabled={loading || secondsLeft <= 0}
+                                >
+                                    {loading ? 'در حال ثبت...' : 'ثبت رمز عبور'}
+                                </button>
+                                <button
+                                    type="button"
+                                    className="register-text-btn"
+                                    onClick={() => {
+                                        setMode('forgot-otp');
+                                        setLoginMessage('');
+                                    }}
+                                    disabled={loading}
+                                >
+                                    بازگشت به کد تأیید
+                                </button>
+                            </div>
+                        </>
+                    )}
 
                     {loginMessage && (
                         <p className={`login-message ${messageType}`}>{loginMessage}</p>

--- a/client/src/components/RegisterPage.css
+++ b/client/src/components/RegisterPage.css
@@ -52,6 +52,13 @@
   text-align: center;
 }
 
+.otp-resend-hint {
+  margin: 0.15rem 0 0.35rem;
+  font-size: 0.85rem;
+  color: var(--ink-muted);
+  text-align: center;
+}
+
 .register-text-btn {
   background: none;
   border: none;

--- a/client/src/components/RegisterPage.js
+++ b/client/src/components/RegisterPage.js
@@ -6,6 +6,7 @@ import './LoginPage.css';
 import './RegisterPage.css';
 
 const OTP_TTL_SEC = 5 * 60;
+const OTP_RESEND_COOLDOWN_SEC = 60;
 const API_BASE = '';
 
 const toEnglishDigits = (value) =>
@@ -42,10 +43,13 @@ const RegisterPage = () => {
     const [messageType, setMessageType] = useState('error');
     const [loading, setLoading] = useState(false);
     const [secondsLeft, setSecondsLeft] = useState(0);
+    const [resendCooldown, setResendCooldown] = useState(0);
     const [showWelcome, setShowWelcome] = useState(false);
     const [devHint, setDevHint] = useState('');
     const [isNewUser, setIsNewUser] = useState(false);
     const expiresAtRef = useRef(null);
+    const resendUntilRef = useRef(null);
+    const sendingRef = useRef(false);
 
     useEffect(() => {
         if (step !== 'otp' || !expiresAtRef.current) return undefined;
@@ -53,6 +57,9 @@ const RegisterPage = () => {
         const tick = () => {
             const left = Math.max(0, Math.ceil((expiresAtRef.current - Date.now()) / 1000));
             setSecondsLeft(left);
+            if (resendUntilRef.current) {
+                setResendCooldown(Math.max(0, Math.ceil((resendUntilRef.current - Date.now()) / 1000)));
+            }
         };
 
         tick();
@@ -70,13 +77,42 @@ const RegisterPage = () => {
         setMessage(text);
     };
 
+    const enterOtpStep = (phone, data, { alreadySent = false } = {}) => {
+        setPhoneInput(phone);
+        expiresAtRef.current = data.expiresAt
+            ? new Date(data.expiresAt).getTime()
+            : Date.now() + (data.expiresInSec || OTP_TTL_SEC) * 1000;
+        setSecondsLeft(
+            data.expiresInSec != null
+                ? data.expiresInSec
+                : Math.max(0, Math.ceil((expiresAtRef.current - Date.now()) / 1000))
+        );
+
+        const cooldownSec = data.retryAfterSec != null ? data.retryAfterSec : OTP_RESEND_COOLDOWN_SEC;
+        resendUntilRef.current = Date.now() + cooldownSec * 1000;
+        setResendCooldown(cooldownSec);
+
+        setOtpInput('');
+        setStep('otp');
+        if (alreadySent) {
+            showError(data.message || 'کد قبلاً ارسال شده است. همان کد را وارد کنید یا کمی صبر کنید.');
+        } else {
+            showSuccess('کد تأیید ارسال شد.');
+        }
+        if (data.devOtp) {
+            setDevHint(`کد آزمایشی: ${data.devOtp}`);
+        }
+    };
+
     const handleSendOtp = async () => {
         const phone = normalizePhone(phoneInput);
         if (!isValidIranMobile(phone)) {
             showError('شماره موبایل معتبر نیست. مثال: ۰۹۱۲xxxxxxx');
             return;
         }
+        if (sendingRef.current) return;
 
+        sendingRef.current = true;
         setLoading(true);
         setMessage('');
         setDevHint('');
@@ -87,25 +123,23 @@ const RegisterPage = () => {
                 body: JSON.stringify({ phone }),
             });
             const data = await response.json();
+
+            // Code was already sent recently — take user to OTP entry instead of leaving them stuck.
+            if (response.status === 429 && (data.codeAlreadySent || data.expiresAt || data.expiresInSec)) {
+                enterOtpStep(phone, data, { alreadySent: true });
+                return;
+            }
+
             if (!response.ok) {
                 showError(data.message || 'ارسال کد ناموفق بود.');
                 return;
             }
 
-            setPhoneInput(phone);
-            expiresAtRef.current = data.expiresAt
-                ? new Date(data.expiresAt).getTime()
-                : Date.now() + (data.expiresInSec || OTP_TTL_SEC) * 1000;
-            setSecondsLeft(data.expiresInSec || OTP_TTL_SEC);
-            setOtpInput('');
-            setStep('otp');
-            showSuccess('کد تأیید ارسال شد.');
-            if (data.devOtp) {
-                setDevHint(`کد آزمایشی: ${data.devOtp}`);
-            }
+            enterOtpStep(phone, data);
         } catch (error) {
             showError('خطا در ارتباط با سرور.');
         } finally {
+            sendingRef.current = false;
             setLoading(false);
         }
     };
@@ -218,9 +252,6 @@ const RegisterPage = () => {
                                 <Link to="/dashboard" className="login-btn login-btn-secondary register-link-btn">
                                     بازگشت به صفحه اصلی
                                 </Link>
-                                <Link to="/login" className="register-text-btn">
-                                    ورود مدیران با رمز عبور
-                                </Link>
                             </div>
                         </>
                     ) : (
@@ -253,6 +284,10 @@ const RegisterPage = () => {
                                 )}
                             </div>
 
+                            {resendCooldown > 0 && (
+                                <p className="otp-resend-hint">ارسال مجدد تا {resendCooldown} ثانیه دیگر</p>
+                            )}
+
                             {devHint && <p className="otp-dev-hint">{devHint}</p>}
 
                             <div className="login-actions">
@@ -268,9 +303,9 @@ const RegisterPage = () => {
                                     type="button"
                                     className="login-btn login-btn-secondary"
                                     onClick={handleSendOtp}
-                                    disabled={loading || (secondsLeft > OTP_TTL_SEC - 60 && secondsLeft > 0)}
+                                    disabled={loading || resendCooldown > 0}
                                 >
-                                    ارسال مجدد کد
+                                    {resendCooldown > 0 ? `ارسال مجدد (${resendCooldown})` : 'ارسال مجدد کد'}
                                 </button>
                                 <button
                                     type="button"
@@ -280,7 +315,9 @@ const RegisterPage = () => {
                                         setOtpInput('');
                                         setMessage('');
                                         setDevHint('');
+                                        setResendCooldown(0);
                                         expiresAtRef.current = null;
+                                        resendUntilRef.current = null;
                                     }}
                                     disabled={loading}
                                 >

--- a/client/src/components/RegisterPage.js
+++ b/client/src/components/RegisterPage.js
@@ -252,6 +252,9 @@ const RegisterPage = () => {
                                 <Link to="/dashboard" className="login-btn login-btn-secondary register-link-btn">
                                     بازگشت به صفحه اصلی
                                 </Link>
+                                <Link to="/login" className="register-text-btn">
+                                    ورود یا تنظیم رمز عبور
+                                </Link>
                             </div>
                         </>
                     ) : (

--- a/server/server.js
+++ b/server/server.js
@@ -125,8 +125,35 @@ function normalizeChildName(childData) {
 const OTP_TTL_MS = 5 * 60 * 1000;
 const OTP_RESEND_COOLDOWN_MS = 60 * 1000;
 const OTP_MAX_ATTEMPTS = 5;
-/** @type {Map<string, { code: string, expiresAt: number, sentAt: number, attempts: number }>} */
+/** @type {Map<string, { code: string, expiresAt: number, sentAt: number, attempts: number, purpose: string }>} */
 const otpStore = new Map();
+/** Phones with an in-flight SMS send — prevents double-send races. */
+const otpPending = new Set();
+
+function otpCooldownResponse(phone, existing) {
+    const now = Date.now();
+    const retryAfterSec = Math.max(
+        1,
+        Math.ceil((OTP_RESEND_COOLDOWN_MS - (now - existing.sentAt)) / 1000)
+    );
+    const expiresInSec = Math.max(0, Math.ceil((existing.expiresAt - now) / 1000));
+    return {
+        message: `لطفاً ${retryAfterSec} ثانیه دیگر برای ارسال مجدد صبر کنید.`,
+        retryAfterSec,
+        expiresInSec,
+        expiresAt: new Date(existing.expiresAt).toISOString(),
+        codeAlreadySent: true,
+        phone
+    };
+}
+
+function validateNewPassword(password) {
+    const value = String(password || '');
+    if (value.length < 4) {
+        return 'رمز عبور باید حداقل ۴ کاراکتر باشد';
+    }
+    return null;
+}
 
 function toEnglishDigits(value) {
     return String(value || '')
@@ -356,33 +383,36 @@ app.post('/api/signup', (req, res) => {
     res.status(201).json({ message: 'ثبت‌نام با موفقیت انجام شد. اکنون می‌توانید وارد شوید.' });
 });
 
-app.post('/api/auth/send-otp', async (req, res) => {
-    const phone = normalizePhone(req.body.phone || req.body.mobile);
-    if (!isValidIranMobile(phone)) {
-        return res.status(400).json({ message: 'شماره موبایل معتبر نیست. مثال: ۰۹۱۲xxxxxxx' });
-    }
-
-    // OTP is used for both login and registration — do not block existing phones.
+async function issueOtp({ phone, purpose, res }) {
     const existing = otpStore.get(phone);
     const now = Date.now();
-    if (existing && now - existing.sentAt < OTP_RESEND_COOLDOWN_MS) {
-        const retryAfterSec = Math.ceil((OTP_RESEND_COOLDOWN_MS - (now - existing.sentAt)) / 1000);
+
+    if (existing && existing.purpose === purpose && now - existing.sentAt < OTP_RESEND_COOLDOWN_MS) {
+        return res.status(429).json(otpCooldownResponse(phone, existing));
+    }
+
+    if (otpPending.has(phone)) {
         return res.status(429).json({
-            message: `لطفاً ${retryAfterSec} ثانیه دیگر برای ارسال مجدد صبر کنید.`,
-            retryAfterSec
+            message: 'در حال ارسال کد هستید. لطفاً چند لحظه صبر کنید.',
+            retryAfterSec: 5,
+            phone
         });
     }
 
     const code = generateOtpCode();
     const expiresAt = now + OTP_TTL_MS;
-    otpStore.set(phone, { code, expiresAt, sentAt: now, attempts: 0 });
+    otpPending.add(phone);
 
     try {
+        // Persist OTP only after SMS succeeds so failed sends do not trigger cooldown.
         await deliverOtp(phone, code);
+        const sentAt = Date.now();
+        otpStore.set(phone, { code, expiresAt, sentAt, attempts: 0, purpose });
     } catch (err) {
-        otpStore.delete(phone);
         console.error('OTP delivery failed:', err);
         return res.status(502).json({ message: 'ارسال کد تأیید ناموفق بود. دوباره تلاش کنید.' });
+    } finally {
+        otpPending.delete(phone);
     }
 
     const payload = {
@@ -395,48 +425,82 @@ app.post('/api/auth/send-otp', async (req, res) => {
     if (process.env.NODE_ENV !== 'production' || !process.env.SMS_API_KEY) {
         payload.devOtp = code;
     }
-    res.status(200).json(payload);
-});
+    return res.status(200).json(payload);
+}
 
-app.post('/api/auth/verify-otp', (req, res) => {
-    const phone = normalizePhone(req.body.phone || req.body.mobile);
-    const code = toEnglishDigits(req.body.code || req.body.otp || '').replace(/\D/g, '');
-
+function readOtpEntry({ phone, code, purpose, consume }) {
     if (!isValidIranMobile(phone)) {
-        return res.status(400).json({ message: 'شماره موبایل معتبر نیست.' });
+        return { error: { status: 400, body: { message: 'شماره موبایل معتبر نیست.' } } };
     }
     if (!/^\d{5}$/.test(code)) {
-        return res.status(400).json({ message: 'کد تأیید باید ۵ رقم باشد.' });
+        return { error: { status: 400, body: { message: 'کد تأیید باید ۵ رقم باشد.' } } };
     }
 
     const entry = otpStore.get(phone);
-    if (!entry) {
-        return res.status(400).json({ message: 'کد تأیید یافت نشد. دوباره درخواست کنید.' });
+    if (!entry || entry.purpose !== purpose) {
+        return { error: { status: 400, body: { message: 'کد تأیید یافت نشد. دوباره درخواست کنید.' } } };
     }
 
     const now = Date.now();
     if (now > entry.expiresAt) {
         otpStore.delete(phone);
-        return res.status(410).json({ message: 'کد تأیید منقضی شده است. دوباره درخواست کنید.' });
+        return { error: { status: 410, body: { message: 'کد تأیید منقضی شده است. دوباره درخواست کنید.' } } };
     }
 
     if (entry.attempts >= OTP_MAX_ATTEMPTS) {
         otpStore.delete(phone);
-        return res.status(429).json({ message: 'تعداد تلاش بیش از حد مجاز است. کد جدید درخواست کنید.' });
+        return {
+            error: {
+                status: 429,
+                body: { message: 'تعداد تلاش بیش از حد مجاز است. کد جدید درخواست کنید.' }
+            }
+        };
     }
 
     if (entry.code !== code) {
         entry.attempts += 1;
         otpStore.set(phone, entry);
         const remaining = OTP_MAX_ATTEMPTS - entry.attempts;
-        return res.status(401).json({
-            message: remaining > 0
-                ? `کد تأیید نادرست است. ${remaining} تلاش باقی مانده.`
-                : 'کد تأیید نادرست است. کد جدید درخواست کنید.'
-        });
+        return {
+            error: {
+                status: 401,
+                body: {
+                    message:
+                        remaining > 0
+                            ? `کد تأیید نادرست است. ${remaining} تلاش باقی مانده.`
+                            : 'کد تأیید نادرست است. کد جدید درخواست کنید.'
+                }
+            }
+        };
     }
 
-    otpStore.delete(phone);
+    if (consume) {
+        otpStore.delete(phone);
+    }
+    return { ok: true, entry };
+}
+
+function consumeOtp({ phone, code, purpose }) {
+    return readOtpEntry({ phone, code, purpose, consume: true });
+}
+
+app.post('/api/auth/send-otp', async (req, res) => {
+    const phone = normalizePhone(req.body.phone || req.body.mobile);
+    if (!isValidIranMobile(phone)) {
+        return res.status(400).json({ message: 'شماره موبایل معتبر نیست. مثال: ۰۹۱۲xxxxxxx' });
+    }
+
+    // OTP is used for both login and registration — do not block existing phones.
+    return issueOtp({ phone, purpose: 'auth', res });
+});
+
+app.post('/api/auth/verify-otp', (req, res) => {
+    const phone = normalizePhone(req.body.phone || req.body.mobile);
+    const code = toEnglishDigits(req.body.code || req.body.otp || '').replace(/\D/g, '');
+    const result = consumeOtp({ phone, code, purpose: 'auth' });
+    if (result.error) {
+        return res.status(result.error.status).json(result.error.body);
+    }
 
     let user = findUserByPhone(phone);
     let isNewUser = false;
@@ -466,6 +530,66 @@ app.post('/api/auth/verify-otp', (req, res) => {
         message: isNewUser ? 'ثبت‌نام با موفقیت انجام شد.' : 'ورود موفقیت‌آمیز.',
         user: publicUser(user),
         isNewUser
+    });
+});
+
+// Forgot / set password via OTP (for users who registered without a password, or forgot it)
+app.post('/api/auth/forgot-password/send-otp', async (req, res) => {
+    const phone = normalizePhone(req.body.phone || req.body.mobile);
+    if (!isValidIranMobile(phone)) {
+        return res.status(400).json({ message: 'شماره موبایل معتبر نیست. مثال: ۰۹۱۲xxxxxxx' });
+    }
+
+    const user = findUserByPhone(phone);
+    if (!user) {
+        return res.status(404).json({
+            message: 'حسابی با این شماره یافت نشد. ابتدا با پیامک ثبت‌نام کنید.'
+        });
+    }
+
+    return issueOtp({ phone, purpose: 'reset', res });
+});
+
+app.post('/api/auth/forgot-password/verify-otp', (req, res) => {
+    const phone = normalizePhone(req.body.phone || req.body.mobile);
+    const code = toEnglishDigits(req.body.code || req.body.otp || '').replace(/\D/g, '');
+    const result = readOtpEntry({ phone, code, purpose: 'reset', consume: false });
+    if (result.error) {
+        return res.status(result.error.status).json(result.error.body);
+    }
+    return res.status(200).json({
+        message: 'کد تأیید صحیح است.',
+        phone,
+        expiresAt: new Date(result.entry.expiresAt).toISOString(),
+        expiresInSec: Math.max(0, Math.ceil((result.entry.expiresAt - Date.now()) / 1000))
+    });
+});
+
+app.post('/api/auth/forgot-password/reset', (req, res) => {
+    const phone = normalizePhone(req.body.phone || req.body.mobile);
+    const code = toEnglishDigits(req.body.code || req.body.otp || '').replace(/\D/g, '');
+    const newPassword = req.body.newPassword || req.body.password;
+    const passwordError = validateNewPassword(newPassword);
+    if (passwordError) {
+        return res.status(400).json({ message: passwordError });
+    }
+
+    const result = consumeOtp({ phone, code, purpose: 'reset' });
+    if (result.error) {
+        return res.status(result.error.status).json(result.error.body);
+    }
+
+    const user = findUserByPhone(phone);
+    if (!user) {
+        return res.status(404).json({ message: 'کاربر یافت نشد.' });
+    }
+
+    users[String(user.id)].password = String(newPassword);
+    saveData();
+
+    res.status(200).json({
+        message: 'رمز عبور با موفقیت ثبت شد. اکنون می‌توانید وارد شوید.',
+        user: publicUser(users[String(user.id)])
     });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fixes OTP send so the code is stored only after successful SMS delivery, and a 429 cooldown response now includes enough metadata for the UI to open the OTP step instead of leaving users stuck on the phone form.
- Adds a forgot/set-password flow on the login page: send OTP → verify OTP → set a new password (for users who registered via SMS without a password, or forgot theirs).
- Removes the public “ورود مدیران با رمز عبور” link from registration. Replaces it with a neutral “ورود یا تنظیم رمز عبور” link. Admins can still open `/login` directly.

## Test plan
- [x] On `/register`, send OTP once and confirm success advances to the code step
- [x] Rapid retry returns 429 with `codeAlreadySent` / `expiresAt` and UI opens OTP step with cooldown
- [x] On `/login`, use “فراموشی رمز عبور / تنظیم رمز” for an existing phone-only user and set a password, then log in with it
- [x] Confirm registration page no longer shows the admin password login wording
- [x] Confirm `/login` still works for password login when opened directly

## Demo
[Register OTP step without admin link](https://cursor.com/agents/bc-c7e54ffc-e704-4da0-86f8-2697fa116743/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fregister-otp-no-admin.webp)
[Login page with forgot password](https://cursor.com/agents/bc-c7e54ffc-e704-4da0-86f8-2697fa116743/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Flogin-page.webp)
[Forgot password OTP step](https://cursor.com/agents/bc-c7e54ffc-e704-4da0-86f8-2697fa116743/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fforgot-otp-step.webp)
[Set new password step](https://cursor.com/agents/bc-c7e54ffc-e704-4da0-86f8-2697fa116743/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fforgot-set-password.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7e54ffc-e704-4da0-86f8-2697fa116743?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7e54ffc-e704-4da0-86f8-2697fa116743&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

