### PR TITLE
Fix profile page desktop layout after OTP signup

### DIFF
--- a/client/src/components/ProfilePage.css
+++ b/client/src/components/ProfilePage.css
@@ -286,17 +286,19 @@
   }
 
   .profile-page > .navbar,
-  .profile-page > .menu-backdrop {
+  .profile-page > .menu-backdrop,
+  .profile-page > .profile-complete-banner,
+  .profile-topbar {
     grid-column: 1 / -1;
   }
 
   .profile-topbar {
-    grid-column: 1 / -1;
     padding-left: 0;
     padding-right: 0;
   }
 
   .profile-tabs {
+    grid-column: 1;
     flex-direction: column;
     overflow: visible;
     margin: 0;
@@ -317,8 +319,10 @@
   }
 
   .profile-content {
+    grid-column: 2;
     margin: 0;
     padding: 0;
+    min-width: 0;
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fixes the broken `/profile` desktop layout when the complete-profile banner is shown (`?complete=1`).
- The banner was not spanning the CSS grid, so it stole the sidebar column and crushed/shifted tabs and content — especially for users coming from OTP registration.

## Test plan
- [ ] Open `/profile?complete=1` on desktop width (≥900px)
- [ ] Confirm the green banner is full-width above the layout
- [ ] Confirm tabs stay in the right sidebar and content stays in the main column
- [ ] Confirm `/profile` without `?complete=1` still looks correct on desktop and mobile
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7e54ffc-e704-4da0-86f8-2697fa116743?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7e54ffc-e704-4da0-86f8-2697fa116743&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

