### PR TITLE
داشبورد: انتقال کودکان به پروفایل، کاور ویدیو، اسکرول موبایل

### DIFF
--- a/client/src/components/ContentRow.css
+++ b/client/src/components/ContentRow.css
@@ -273,7 +273,7 @@
   }
 
   .content-row.scrollable {
-    --visible-count: 4;
+    --visible-count: var(--desktop-visible-count, 4);
     --row-gap: 1.25rem;
     flex-wrap: nowrap;
     overflow-x: auto;

--- a/client/src/components/ContentRow.css
+++ b/client/src/components/ContentRow.css
@@ -197,34 +197,49 @@
     font-size: 1.1rem;
   }
 
+  .content-row-viewport {
+    padding: 0;
+  }
+
   .content-row,
   .content-row.scrollable {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.75rem;
-    overflow: visible;
-    scroll-snap-type: none;
-    padding-bottom: 0.25rem;
-    padding-inline: 0;
+    --visible-count: var(--mobile-visible-count, 2);
+    --row-gap: 0.75rem;
+    display: flex;
+    flex-wrap: nowrap;
+    gap: var(--row-gap);
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scroll-snap-type: x mandatory;
+    scrollbar-width: none;
+    padding: 0.15rem 0 0.85rem;
   }
 
-  .content-row.scrollable .content-card-link,
-  .content-card-link {
-    flex: unset;
-    width: 100%;
+  .content-row::-webkit-scrollbar,
+  .content-row.scrollable::-webkit-scrollbar {
+    display: none;
+  }
+
+  .content-row .content-card-link,
+  .content-row.scrollable .content-card-link {
+    flex: 0 0 calc((100% - (var(--visible-count) - 1) * var(--row-gap)) / var(--visible-count));
+    max-width: none;
     min-width: 0;
+    width: auto;
+    scroll-snap-align: start;
   }
 
-  .content-row.scrollable .content-card,
-  .content-card {
-    flex: unset;
+  .content-row .content-card,
+  .content-row.scrollable .content-card {
+    flex: 1 1 auto;
     width: 100%;
+    max-width: none;
     min-height: 0;
     height: auto;
   }
 
-  .content-row.scrollable .content-card img,
-  .content-card img {
+  .content-row .content-card img,
+  .content-row.scrollable .content-card img {
     height: 100%;
   }
 

--- a/client/src/components/ContentRow.js
+++ b/client/src/components/ContentRow.js
@@ -143,7 +143,7 @@ const ContentRow = ({
                     style={
                         scrollable
                             ? {
-                                '--visible-count': visibleCount,
+                                '--desktop-visible-count': visibleCount,
                                 '--mobile-visible-count': mobileVisibleCount,
                             }
                             : undefined

--- a/client/src/components/ContentRow.js
+++ b/client/src/components/ContentRow.js
@@ -4,7 +4,14 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import './ContentRow.css';
 
-const ContentRow = ({ title, items, viewAllLink, scrollable = false, visibleCount = 4 }) => {
+const ContentRow = ({
+    title,
+    items,
+    viewAllLink,
+    scrollable = false,
+    visibleCount = 4,
+    mobileVisibleCount = 2,
+}) => {
     const rowRef = useRef(null);
     const [canScrollPrev, setCanScrollPrev] = useState(false);
     const [canScrollNext, setCanScrollNext] = useState(false);
@@ -44,7 +51,7 @@ const ContentRow = ({ title, items, viewAllLink, scrollable = false, visibleCoun
             el.removeEventListener('scroll', updateScrollState);
             window.removeEventListener('resize', updateScrollState);
         };
-    }, [scrollable, items, visibleCount]);
+    }, [scrollable, items, visibleCount, mobileVisibleCount]);
 
     const scrollByPage = (direction) => {
         const el = rowRef.current;
@@ -133,7 +140,14 @@ const ContentRow = ({ title, items, viewAllLink, scrollable = false, visibleCoun
                 <div
                     ref={rowRef}
                     className={`content-row ${scrollable ? 'scrollable' : ''}`}
-                    style={scrollable ? { '--visible-count': visibleCount } : undefined}
+                    style={
+                        scrollable
+                            ? {
+                                '--visible-count': visibleCount,
+                                '--mobile-visible-count': mobileVisibleCount,
+                            }
+                            : undefined
+                    }
                 >
                     {items.map(renderItem)}
                 </div>

--- a/client/src/components/DashboardPage.js
+++ b/client/src/components/DashboardPage.js
@@ -99,6 +99,7 @@ const DashboardPage = () => {
                     items={videos}
                     scrollable={true}
                     visibleCount={4}
+                    mobileVisibleCount={2}
                     viewAllLink="/news#educational-videos"
                 />
                 <ContentRow
@@ -106,6 +107,7 @@ const DashboardPage = () => {
                     items={articles}
                     scrollable={true}
                     visibleCount={4}
+                    mobileVisibleCount={2}
                     viewAllLink="/news"
                 />
             </main>

--- a/client/src/components/MainNavbar.js
+++ b/client/src/components/MainNavbar.js
@@ -49,7 +49,6 @@ const MainNavbar = () => {
                         <Link to="/dashboard" onClick={closeMenu}>داشبورد</Link>
                         <Link to="/news" onClick={closeMenu}>مجله سلامت</Link>
                         <Link to="/shop" onClick={closeMenu}>فروشگاه</Link>
-                        <Link to="/my-children" onClick={closeMenu}>فرزندان من</Link>
                         {isAdmin && (
                             <Link to="/admin" className="admin-link" onClick={closeMenu}>
                                 پنل مدیریت

--- a/client/src/components/ProfilePage.js
+++ b/client/src/components/ProfilePage.js
@@ -35,6 +35,7 @@ const ProfilePage = () => {
 
     const tabs = [
         { id: 'userInfo', label: 'اطلاعات' },
+        { id: 'myChildren', label: 'کودکان من', href: '/my-children' },
         { id: 'messages', label: 'پیام‌ها' },
         { id: 'orders', label: 'سفارش‌ها', href: '/orders' },
         { id: 'changePassword', label: 'رمز عبور' }

--- a/client/src/components/ServiceTiles.css
+++ b/client/src/components/ServiceTiles.css
@@ -266,13 +266,33 @@
   }
 
   .tiles-container {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.65rem;
+    --tile-visible-count: 2;
+    --tile-gap: 0.65rem;
+    display: flex;
+    flex-wrap: nowrap;
+    gap: var(--tile-gap);
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scroll-snap-type: x mandatory;
+    scrollbar-width: none;
+    padding-bottom: 0.35rem;
+  }
+
+  .tiles-container::-webkit-scrollbar {
+    display: none;
+  }
+
+  .tiles-container > .tile-link {
+    flex: 0 0 calc((100% - (var(--tile-visible-count) - 1) * var(--tile-gap)) / var(--tile-visible-count));
+    width: auto;
+    max-width: none;
+    scroll-snap-align: start;
   }
 
   .tile {
     min-height: 104px;
     padding: 0.9rem 0.5rem;
+    height: 100%;
   }
 
   .tile-icon {

--- a/client/src/components/ServiceTiles.js
+++ b/client/src/components/ServiceTiles.js
@@ -3,7 +3,6 @@ import { Link, useHistory } from 'react-router-dom';
 import Modal from 'react-modal';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
-    faChild,
     faChartLine,
     faSyringe,
     faUserMd,
@@ -17,7 +16,6 @@ import { getChildDisplayName } from '../utils/childName';
 import './ServiceTiles.css';
 
 const services = [
-    { name: 'کودکان من', icon: faChild, link: '/my-children', id: 'my-children', tone: 'teal' },
     { name: 'راهنمای سنی', icon: faSeedling, link: '#', id: 'age-guidance', tone: 'mint' },
     { name: 'نمودار رشد', icon: faChartLine, link: '#', id: 'growth-chart', tone: 'amber' },
     { name: 'واکسیناسیون', icon: faSyringe, link: '#', id: 'vaccination', tone: 'mint' },

--- a/client/src/components/admin/VideoManagement.css
+++ b/client/src/components/admin/VideoManagement.css
@@ -8,7 +8,38 @@
 .video-management h2 {
     text-align: right;
     color: #2c3e50;
-    margin-bottom: 1.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.video-management-hint {
+    text-align: right;
+    color: #5f6b7a;
+    font-size: 0.92rem;
+    line-height: 1.6;
+    margin: 0 0 1.25rem;
+}
+
+.video-thumbnail-label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    text-align: right;
+    font-weight: 600;
+    color: #2c3e50;
+}
+
+.video-thumbnail-preview {
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    overflow: hidden;
+    max-width: 320px;
+}
+
+.video-thumbnail-preview img {
+    display: block;
+    width: 100%;
+    aspect-ratio: 16 / 10;
+    object-fit: cover;
 }
 
 .btn-add-video {
@@ -67,6 +98,37 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 1rem;
+}
+
+.video-item-media {
+    width: 120px;
+    flex-shrink: 0;
+    border-radius: 8px;
+    overflow: hidden;
+    background: #0f766e;
+    aspect-ratio: 16 / 10;
+}
+
+.video-item-media img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.video-item-fallback {
+    width: 100%;
+    height: 100%;
+    display: grid;
+    place-items: center;
+    color: rgba(255, 255, 255, 0.9);
+    font-size: 1.5rem;
+}
+
+.video-item-info {
+    flex: 1;
+    min-width: 0;
 }
 
 .video-item-info h3 {

--- a/client/src/components/admin/VideoManagement.js
+++ b/client/src/components/admin/VideoManagement.js
@@ -5,7 +5,8 @@ const VideoManagement = () => {
     const [videos, setVideos] = useState([]);
     const [loading, setLoading] = useState(true);
     const [showForm, setShowForm] = useState(false);
-    const [newVideo, setNewVideo] = useState({ title: '', url: '', summary: '' });
+    const [newVideo, setNewVideo] = useState({ title: '', url: '', summary: '', thumbnail: null });
+    const [thumbnailPreview, setThumbnailPreview] = useState(null);
 
     const fetchVideos = async () => {
         setLoading(true);
@@ -25,28 +26,62 @@ const VideoManagement = () => {
         fetchVideos();
     }, []);
 
+    useEffect(() => () => {
+        if (thumbnailPreview) URL.revokeObjectURL(thumbnailPreview);
+    }, [thumbnailPreview]);
+
     const handleInputChange = (e) => {
         const { name, value } = e.target;
-        setNewVideo(prev => ({ ...prev, [name]: value }));
+        setNewVideo((prev) => ({ ...prev, [name]: value }));
+    };
+
+    const handleThumbnailChange = (e) => {
+        const file = e.target.files?.[0] || null;
+        setNewVideo((prev) => ({ ...prev, thumbnail: file }));
+        setThumbnailPreview((prev) => {
+            if (prev) URL.revokeObjectURL(prev);
+            return file ? URL.createObjectURL(file) : null;
+        });
+    };
+
+    const resetForm = () => {
+        setNewVideo({ title: '', url: '', summary: '', thumbnail: null });
+        setThumbnailPreview((prev) => {
+            if (prev) URL.revokeObjectURL(prev);
+            return null;
+        });
     };
 
     const handleSubmit = async (e) => {
         e.preventDefault();
+        if (!newVideo.thumbnail) {
+            alert('لطفاً یک تصویر کاور برای ویدیو آپلود کنید تا روی داشبورد نمایش داده شود.');
+            return;
+        }
+
+        const formData = new FormData();
+        formData.append('title', newVideo.title);
+        formData.append('url', newVideo.url);
+        formData.append('summary', newVideo.summary);
+        formData.append('thumbnail', newVideo.thumbnail);
+
         try {
             const adminUser = JSON.parse(localStorage.getItem('loggedInUser'));
             const response = await fetch('/api/admin/videos', {
                 method: 'POST',
                 headers: {
-                    'Content-Type': 'application/json',
-                    'x-user-id': adminUser.id
+                    'x-user-id': adminUser.id,
                 },
-                body: JSON.stringify(newVideo),
+                body: formData,
             });
-            if (!response.ok) throw new Error('Failed to create video');
+            if (!response.ok) {
+                const errData = await response.json().catch(() => ({}));
+                throw new Error(errData.message || 'Failed to create video');
+            }
 
-            fetchVideos(); // Re-fetch to get the new list
+            fetchVideos();
             setShowForm(false);
-            setNewVideo({ title: '', url: '', summary: '' });
+            resetForm();
             alert('ویدیو با موفقیت ایجاد شد');
         } catch (err) {
             console.error(err.message);
@@ -60,9 +95,9 @@ const VideoManagement = () => {
                 const adminUser = JSON.parse(localStorage.getItem('loggedInUser'));
                 await fetch(`/api/admin/videos/${videoId}`, {
                     method: 'DELETE',
-                    headers: { 'x-user-id': adminUser.id }
+                    headers: { 'x-user-id': adminUser.id },
                 });
-                fetchVideos(); // Re-fetch
+                fetchVideos();
                 alert('ویدیو حذف شد');
             } catch (err) {
                 alert(`خطا در حذف: ${err.message}`);
@@ -73,32 +108,86 @@ const VideoManagement = () => {
     return (
         <div className="video-management">
             <h2>مدیریت ویدیوها</h2>
+            <p className="video-management-hint">
+                لینک پخش (آپارات/یوتیوب) را وارد کنید و حتماً یک تصویر کاور آپلود کنید تا روی کارت ویدیو در داشبورد نمایش داده شود.
+            </p>
             <button onClick={() => setShowForm(!showForm)} className="btn-add-video">
                 {showForm ? 'پنهان کردن فرم' : 'افزودن ویدیوی جدید'}
             </button>
 
             {showForm && (
                 <form onSubmit={handleSubmit} className="video-form">
-                    <input type="text" name="title" value={newVideo.title} onChange={handleInputChange} placeholder="عنوان" required />
-                    <input type="url" name="url" value={newVideo.url} onChange={handleInputChange} placeholder="URL ویدیو (مثلا لینک آپارات)" required />
-                    <textarea name="summary" value={newVideo.summary} onChange={handleInputChange} placeholder="توضیحات (اختیاری)" rows="3"></textarea>
+                    <input
+                        type="text"
+                        name="title"
+                        value={newVideo.title}
+                        onChange={handleInputChange}
+                        placeholder="عنوان"
+                        required
+                    />
+                    <input
+                        type="url"
+                        name="url"
+                        value={newVideo.url}
+                        onChange={handleInputChange}
+                        placeholder="لینک پخش ویدیو (مثلاً آپارات)"
+                        required
+                    />
+                    <textarea
+                        name="summary"
+                        value={newVideo.summary}
+                        onChange={handleInputChange}
+                        placeholder="توضیحات (اختیاری)"
+                        rows="3"
+                    />
+                    <label className="video-thumbnail-label">
+                        تصویر کاور ویدیو
+                        <input
+                            type="file"
+                            accept="image/*"
+                            onChange={handleThumbnailChange}
+                            required
+                        />
+                    </label>
+                    {thumbnailPreview && (
+                        <div className="video-thumbnail-preview">
+                            <img src={thumbnailPreview} alt="پیش‌نمایش کاور" />
+                        </div>
+                    )}
                     <button type="submit">ذخیره ویدیو</button>
                 </form>
             )}
 
             <div className="videos-list">
-                {loading ? <p>در حال بارگذاری...</p> : videos.map(video => (
-                    <div key={video.id} className="video-item">
-                        <div className="video-item-info">
-                            <h3>{video.title}</h3>
-                            <a href={video.url} target="_blank" rel="noopener noreferrer">{video.url}</a>
-                            <p>{video.summary}</p>
+                {loading ? (
+                    <p>در حال بارگذاری...</p>
+                ) : (
+                    videos.map((video) => (
+                        <div key={video.id} className="video-item">
+                            <div className="video-item-media">
+                                {video.thumbnailUrl ? (
+                                    <img src={video.thumbnailUrl} alt={video.title} />
+                                ) : (
+                                    <div className="video-item-fallback" aria-hidden="true">
+                                        ▶
+                                    </div>
+                                )}
+                            </div>
+                            <div className="video-item-info">
+                                <h3>{video.title}</h3>
+                                <a href={video.url} target="_blank" rel="noopener noreferrer">
+                                    {video.url}
+                                </a>
+                                <p>{video.summary}</p>
+                            </div>
+                            <div className="video-item-actions">
+                                <button onClick={() => handleDelete(video.id)} className="btn-delete">
+                                    حذف
+                                </button>
+                            </div>
                         </div>
-                        <div className="video-item-actions">
-                            <button onClick={() => handleDelete(video.id)} className="btn-delete">حذف</button>
-                        </div>
-                    </div>
-                ))}
+                    ))
+                )}
             </div>
         </div>
     );

--- a/server/server.js
+++ b/server/server.js
@@ -1279,10 +1279,18 @@ app.delete('/api/admin/news/:id', isAdmin, (req, res) => {
 });
 
 app.get('/api/videos', (req, res) => res.json(videos));
-app.post('/api/admin/videos', isAdmin, (req, res) => {
+app.post('/api/admin/videos', isAdmin, upload.single('thumbnail'), (req, res) => {
     const { title, url, summary } = req.body;
     if (!title || !url) return res.status(400).json({ message: 'Title and URL are required' });
-    const newVideo = { id: Date.now(), title, url, summary, createdAt: new Date().toISOString() };
+    if (!req.file) return res.status(400).json({ message: 'تصویر کاور ویدیو الزامی است' });
+    const newVideo = {
+        id: Date.now(),
+        title,
+        url,
+        summary: summary || '',
+        thumbnailUrl: `/uploads/${req.file.filename}`,
+        createdAt: new Date().toISOString(),
+    };
     videos.unshift(newVideo);
     saveData();
     res.status(201).json(newVideo);
@@ -1290,9 +1298,16 @@ app.post('/api/admin/videos', isAdmin, (req, res) => {
 app.delete('/api/admin/videos/:id', isAdmin, (req, res) => {
     const { id } = req.params;
     const initialLength = videos.length;
+    const removed = videos.find(v => v.id === parseInt(id));
     videos = videos.filter(v => v.id !== parseInt(id));
-    if (videos.length < initialLength) { saveData(); res.status(200).json({ message: 'ویدیو با موفقیت حذف شد' }); }
-    else res.status(404).json({ message: 'ویدیو یافت نشد' });
+    if (videos.length < initialLength) {
+        if (removed?.thumbnailUrl && removed.thumbnailUrl.startsWith('/uploads/')) {
+            const filePath = path.join(uploadsDir, path.basename(removed.thumbnailUrl));
+            fs.unlink(filePath, () => {});
+        }
+        saveData();
+        res.status(200).json({ message: 'ویدیو با موفقیت حذف شد' });
+    } else res.status(404).json({ message: 'ویدیو یافت نشد' });
 });
 
 app.get('/api/podcasts', (req, res) => res.json(podcasts));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## خلاصه
بهبود UX داشبورد طبق بازخورد محصول:

1. **کودکان من** از کاشی‌های داشبورد و لینک هدر حذف شد و به تب‌های پروفایل کاربری منتقل شد.
2. **ویدیوها**: در پنل ادمین آپلود تصویر کاور اجباری شد تا روی کارت ویدیو در داشبورد عکس نمایش داده شود (لینک پخش آپارات/یوتیوب حفظ می‌شود — نیازی به آپلود فایل ویدیو نیست).
3. **موبایل**: به‌جای چیدن چند ردیف زیر هم، در ردیف ویدیو/مقاله و کاشی خدمات فقط ۲ آیتم دیده می‌شود و بقیه با اسکرول افقی در دسترس است.

## Walkthrough
[موبایل: ۲ کاشی + ۲ ویدیو](https://cursor.com/agents/bc-e45460e6-a5ab-4aa5-9a59-c814e22843b3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmobile-dashboard-2-items.webp)
[کاور ویدیو روی کارت](https://cursor.com/agents/bc-e45460e6-a5ab-4aa5-9a59-c814e22843b3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdesktop-video-cover.webp)
[تب کودکان من در پروفایل](https://cursor.com/agents/bc-e45460e6-a5ab-4aa5-9a59-c814e22843b3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fprofile-kids-tab.webp)
[منوی موبایل بدون فرزندان من](https://cursor.com/agents/bc-e45460e6-a5ab-4aa5-9a59-c814e22843b3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmobile-menu-no-kids.webp)

## تست انجام‌شده
- [x] داشبورد دیگر کاشی «کودکان من» ندارد
- [x] هدر/منو لینک «فرزندان من» ندارد
- [x] پروفایل تب «کودکان من» دارد و به `/my-children` می‌رود
- [x] افزودن ویدیو بدون کاور با ۴۰۰ رد می‌شود؛ با کاور روی داشبورد عکس دیده می‌شود
- [x] در عرض موبایل (~۳۹۰px)، ردیف‌ها و کاشی‌ها ۲تایی + اسکرول افقی هستند

## نکته محصول
برای نمایش عکس روی کارت ویدیو، **آپلود کاور** کافی است؛ لینک آپارات برای پخش باقی می‌ماند. آپلود فایل کامل ویدیو لازم نیست و حجم/پهنای‌باند را بی‌دلیل بالا می‌برد. دسترسی سریع موبایل به فرزندان از طریق نوار پایین حفظ شده است.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e45460e6-a5ab-4aa5-9a59-c814e22843b3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e45460e6-a5ab-4aa5-9a59-c814e22843b3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

