### PR TITLE
موبایل: کاشی خدمات دوباره گرید کامل باشد

### DIFF
--- a/client/src/components/ServiceTiles.css
+++ b/client/src/components/ServiceTiles.css
@@ -266,33 +266,14 @@
   }
 
   .tiles-container {
-    --tile-visible-count: 2;
-    --tile-gap: 0.65rem;
-    display: flex;
-    flex-wrap: nowrap;
-    gap: var(--tile-gap);
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    scroll-snap-type: x mandatory;
-    scrollbar-width: none;
-    padding-bottom: 0.35rem;
-  }
-
-  .tiles-container::-webkit-scrollbar {
-    display: none;
-  }
-
-  .tiles-container > .tile-link {
-    flex: 0 0 calc((100% - (var(--tile-visible-count) - 1) * var(--tile-gap)) / var(--tile-visible-count));
-    width: auto;
-    max-width: none;
-    scroll-snap-align: start;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.65rem;
   }
 
   .tile {
     min-height: 104px;
     padding: 0.9rem 0.5rem;
-    height: 100%;
   }
 
   .tile-icon {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## خلاصه
اسکرول افقی ۲تایی فقط برای ردیف ویدیو و مقاله است. کاشی‌های «خدمات تات کیدز» در موبایل دوباره به گرید ۲ستونه برمی‌گردند و همه کاشی‌ها زیر هم دیده می‌شوند.

## تست
- [ ] موبایل: کاشی خدمات گرید ۲ستونه (نه اسکرول افقی)
- [ ] موبایل: ویدیو و مقاله همچنان ۲ کارت + اسکرول افقی

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e45460e6-a5ab-4aa5-9a59-c814e22843b3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e45460e6-a5ab-4aa5-9a59-c814e22843b3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

