### PR TITLE
Fix mobile hamburger menu options not working

### DIFF
--- a/client/src/components/MainNavbar.css
+++ b/client/src/components/MainNavbar.css
@@ -14,6 +14,13 @@
   backdrop-filter: blur(8px);
 }
 
+/* Keep the whole nav (drawer + toggler) above the sibling backdrop.
+   Sticky + z-index creates a stacking context that would otherwise trap
+   the drawer's z-index below .menu-backdrop and swallow link taps. */
+.navbar.menu-open {
+  z-index: 2100;
+}
+
 .navbar-left,
 .navbar-center,
 .navbar-right {
@@ -161,7 +168,8 @@
   width: 100%;
   height: 100%;
   background-color: rgba(15, 61, 58, 0.45);
-  z-index: 1999;
+  /* Above page chrome (e.g. bottom nav 1500), below .navbar.menu-open (2100) */
+  z-index: 2050;
   animation: fade-up 0.25s ease both;
 }
 
@@ -238,7 +246,9 @@
     display: block;
   }
 
-  .menu-backdrop {
-    z-index: 1998;
+  /* Keep the close control above the slide-in drawer panel */
+  .navbar.menu-open .navbar-right {
+    position: relative;
+    z-index: 2001;
   }
 }

--- a/client/src/components/MainNavbar.js
+++ b/client/src/components/MainNavbar.js
@@ -31,7 +31,7 @@ const MainNavbar = () => {
 
     return (
         <>
-            <nav className="navbar">
+            <nav className={`navbar ${isMenuOpen ? 'menu-open' : ''}`}>
                 <div className="navbar-left">
                     <div className="navbar-brand">
                         <Link to="/dashboard" onClick={closeMenu}>
@@ -80,7 +80,7 @@ const MainNavbar = () => {
                     </button>
                 </div>
             </nav>
-            {isMenuOpen && <div className="menu-backdrop" onClick={closeMenu} />}
+            {isMenuOpen && <div className="menu-backdrop" onClick={closeMenu} aria-hidden="true" />}
         </>
     );
 };

--- a/client/src/components/NewsHeader.css
+++ b/client/src/components/NewsHeader.css
@@ -13,6 +13,11 @@
   z-index: 1000;
 }
 
+/* Keep drawer + toggler above the sibling backdrop (same stacking trap as MainNavbar). */
+.news-navbar.menu-open {
+  z-index: 2100;
+}
+
 .news-navbar .navbar-left,
 .news-navbar .navbar-center,
 .news-navbar .navbar-right {
@@ -112,7 +117,8 @@
   width: 100%;
   height: 100%;
   background-color: rgba(15, 61, 58, 0.45);
-  z-index: 1999;
+  /* Above page chrome, below .news-navbar.menu-open (2100) */
+  z-index: 2050;
 }
 
 @media (max-width: 900px) {
@@ -122,16 +128,23 @@
     right: 0;
     width: min(280px, 85vw);
     height: 100%;
+    height: 100dvh;
     background: linear-gradient(180deg, var(--brand-deep), var(--brand));
-    padding: 1.75rem 1rem;
+    padding: 1.75rem 1rem calc(1.75rem + env(safe-area-inset-bottom, 0px));
     z-index: 2000;
     display: block;
-    transform: translateX(100%);
-    transition: transform 0.3s ease-in-out;
+    transform: translate3d(110%, 0, 0);
+    transition: transform 0.28s ease, visibility 0.28s ease;
+    visibility: hidden;
+    pointer-events: none;
+    overflow-y: auto;
+    box-shadow: -8px 0 28px rgba(0, 0, 0, 0.22);
   }
 
   .news-navbar .navbar-center.active {
-    transform: translateX(0);
+    transform: translate3d(0, 0, 0);
+    visibility: visible;
+    pointer-events: auto;
   }
 
   .news-navbar .navbar-links {
@@ -148,6 +161,13 @@
 
   .news-navbar .navbar-toggler {
     display: block;
+    min-width: var(--tap-min, 44px);
+    min-height: var(--tap-min, 44px);
+  }
+
+  .news-navbar.menu-open .navbar-right {
+    position: relative;
+    z-index: 2001;
   }
 
   .news-login-cta--desktop {

--- a/client/src/components/NewsHeader.js
+++ b/client/src/components/NewsHeader.js
@@ -1,13 +1,17 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import './NewsHeader.css';
 
 const NewsHeader = () => {
     const [isMenuOpen, setIsMenuOpen] = useState(false);
 
-    const toggleMenu = () => {
-        setIsMenuOpen(!isMenuOpen);
-    };
+    const closeMenu = () => setIsMenuOpen(false);
+    const toggleMenu = () => setIsMenuOpen((open) => !open);
+
+    useEffect(() => {
+        document.body.classList.toggle('nav-drawer-open', isMenuOpen);
+        return () => document.body.classList.remove('nav-drawer-open');
+    }, [isMenuOpen]);
 
     const isLoggedIn = (() => {
         try {
@@ -22,27 +26,27 @@ const NewsHeader = () => {
 
     return (
         <>
-            <nav className="news-navbar">
+            <nav className={`news-navbar ${isMenuOpen ? 'menu-open' : ''}`}>
                 <div className="navbar-left">
                     <div className="navbar-brand">
-                        <Link to="/news">مجله سلامت تات کیدز</Link>
+                        <Link to="/news" onClick={closeMenu}>مجله سلامت تات کیدز</Link>
                     </div>
                 </div>
 
                 <div className={`navbar-center ${isMenuOpen ? 'active' : ''}`}>
                     <div className="navbar-links">
-                        <Link to={{ pathname: "/news", state: { category: 'همه' } }} onClick={() => setIsMenuOpen(false)}>همه</Link>
-                        <Link to={{ pathname: "/news", state: { category: 'بیماری' } }} onClick={() => setIsMenuOpen(false)}>بیماری</Link>
-                        <Link to={{ pathname: "/news", state: { category: 'آموزشی' } }} onClick={() => setIsMenuOpen(false)}>آموزش</Link>
-                        <Link to={{ pathname: "/news", state: { category: 'تغذیه' } }} onClick={() => setIsMenuOpen(false)}>تغذیه</Link>
-                        <Link to={{ pathname: "/news", state: { category: 'مادر و کودک' } }} onClick={() => setIsMenuOpen(false)}>مادر و کودک</Link>
-                        <Link to={{ pathname: "/news", state: { category: 'تربیتی' } }} onClick={() => setIsMenuOpen(false)}>تربیتی</Link>
+                        <Link to={{ pathname: "/news", state: { category: 'همه' } }} onClick={closeMenu}>همه</Link>
+                        <Link to={{ pathname: "/news", state: { category: 'بیماری' } }} onClick={closeMenu}>بیماری</Link>
+                        <Link to={{ pathname: "/news", state: { category: 'آموزشی' } }} onClick={closeMenu}>آموزش</Link>
+                        <Link to={{ pathname: "/news", state: { category: 'تغذیه' } }} onClick={closeMenu}>تغذیه</Link>
+                        <Link to={{ pathname: "/news", state: { category: 'مادر و کودک' } }} onClick={closeMenu}>مادر و کودک</Link>
+                        <Link to={{ pathname: "/news", state: { category: 'تربیتی' } }} onClick={closeMenu}>تربیتی</Link>
                         {isLoggedIn ? (
-                            <Link to="/dashboard" className="news-login-cta" onClick={() => setIsMenuOpen(false)}>
+                            <Link to="/dashboard" className="news-login-cta" onClick={closeMenu}>
                                 داشبورد
                             </Link>
                         ) : (
-                            <Link to="/register" className="news-login-cta" onClick={() => setIsMenuOpen(false)}>
+                            <Link to="/register" className="news-login-cta" onClick={closeMenu}>
                                 ورود / ثبت‌نام
                             </Link>
                         )}
@@ -67,11 +71,11 @@ const NewsHeader = () => {
                         aria-label="منو"
                         aria-expanded={isMenuOpen}
                     >
-                        &#9776;
+                        {isMenuOpen ? '✕' : '☰'}
                     </button>
                 </div>
             </nav>
-            {isMenuOpen && <div className="menu-backdrop" onClick={toggleMenu} />}
+            {isMenuOpen && <div className="menu-backdrop" onClick={closeMenu} aria-hidden="true" />}
         </>
     );
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fixed a stacking-context bug where the mobile menu backdrop sat above the slide-in drawer, so taps closed the menu instead of navigating.
- Applied the same fix to both `MainNavbar` and `NewsHeader`.
- Kept the close (✕) control above the drawer and locked body scroll for the news header drawer as well.

## Root cause
`.navbar` / `.news-navbar` use `position: sticky` + `z-index: 1000`, which creates a stacking context. The drawer’s `z-index: 2000` only applied inside that context, while `.menu-backdrop` was a sibling at `~1999` — so every tap hit the backdrop’s `closeMenu` handler.

## Fix
- Add `menu-open` class and raise open navbar to `z-index: 2100`
- Place backdrop at `z-index: 2050` (above bottom nav, below drawer/nav)
- Keep toggler/`navbar-right` above the drawer panel

## Testing (iPhone 12 Pro, 390×844)
Verified on localhost:
- MainNavbar links: Dashboard → News → Shop → Admin all navigate correctly
- NewsHeader category links filter content and close the menu
- Backdrop tap closes menu
- ✕ closes menu

[Mobile hamburger menu open](https://cursor.com/agents/bc-59d4f7aa-8772-4ebc-a6a7-ab68e404613c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmobile-menu-open.webp)
[Navigated to news from menu](https://cursor.com/agents/bc-59d4f7aa-8772-4ebc-a6a7-ab68e404613c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fnav-to-news.webp)
[News category filter from menu](https://cursor.com/agents/bc-59d4f7aa-8772-4ebc-a6a7-ab68e404613c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fnews-category-filter.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59d4f7aa-8772-4ebc-a6a7-ab68e404613c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59d4f7aa-8772-4ebc-a6a7-ab68e404613c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

