### PR TITLE
بهبود صفحه نمودار رشد برای موبایل

### DIFF
--- a/client/src/components/GrowthChartPage.css
+++ b/client/src/components/GrowthChartPage.css
@@ -1,7 +1,7 @@
 .growth-chart-page {
   max-width: 720px;
   margin: 0 auto;
-  padding: 0 0.85rem 6.5rem;
+  padding: 0 0.85rem 7.75rem;
   overflow-x: hidden;
 }
 
@@ -60,9 +60,9 @@
 .gc-hero {
   display: flex;
   align-items: center;
-  gap: 0.85rem;
-  padding: 0.95rem 1rem;
-  margin-bottom: 0.85rem;
+  gap: 0.7rem;
+  padding: 0.75rem 0.85rem;
+  margin-bottom: 0.7rem;
   border-radius: var(--radius-md);
   background: linear-gradient(145deg, #0f766e 0%, #115e59 70%, #0b3d3a 100%);
   color: #fff;
@@ -70,20 +70,20 @@
 }
 
 .gc-hero-icon {
-  width: 48px;
-  height: 48px;
-  flex: 0 0 48px;
+  width: 40px;
+  height: 40px;
+  flex: 0 0 40px;
   border-radius: 50%;
   display: grid;
   place-items: center;
   background: rgba(255, 255, 255, 0.14);
-  font-size: 1.25rem;
+  font-size: 1.1rem;
 }
 
 .gc-hero-text h2 {
-  margin: 0.1rem 0 0.25rem;
+  margin: 0.05rem 0 0.15rem;
   color: #fff;
-  font-size: 1.2rem;
+  font-size: 1.08rem;
 }
 
 .gc-kicker {
@@ -109,11 +109,11 @@
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0.45rem;
-  margin-bottom: 0.85rem;
+  margin-bottom: 0.7rem;
 }
 
 .gc-tab {
-  min-height: 58px;
+  min-height: 52px;
   border: 1px solid var(--border);
   border-radius: 12px;
   background: var(--surface);
@@ -307,7 +307,32 @@
 
 .gc-chart-wrap {
   width: 100%;
-  overflow: hidden;
+  min-height: 300px;
+}
+
+.gc-legend-chips {
+  list-style: none;
+  margin: 0.65rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.45rem 0.75rem;
+}
+
+.gc-legend-chips li {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #3f4f4d;
+}
+
+.gc-legend-chips i {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
 }
 
 .gc-tooltip {
@@ -696,9 +721,9 @@
     position: fixed;
     left: 0.85rem;
     right: 0.85rem;
-    bottom: calc(72px + env(safe-area-inset-bottom, 0px));
+    bottom: calc(76px + env(safe-area-inset-bottom, 0px));
     z-index: 1400;
-    min-height: 48px;
+    min-height: 46px;
     border: none;
     border-radius: 14px;
     background: var(--brand);

--- a/client/src/components/GrowthChartPage.css
+++ b/client/src/components/GrowthChartPage.css
@@ -1,358 +1,616 @@
 .growth-chart-page {
-  padding: 1rem;
-  background-color: transparent;
-  max-width: 1100px;
+  max-width: 720px;
   margin: 0 auto;
+  padding: 0 0.85rem 6.5rem;
+  overflow-x: hidden;
 }
 
-.growth-loading {
+.gc-loading {
   text-align: center;
-  padding: 2rem;
+  padding: 3rem 1rem;
   color: var(--ink-muted);
 }
 
-.page-nav-final {
-  display: flex;
-  justify-content: space-between;
+.gc-nav {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.9rem 1rem;
-  background: linear-gradient(120deg, var(--brand-soft), var(--surface));
+  position: sticky;
+  top: 0;
+  z-index: 900;
+  margin: 0 -0.85rem 0.9rem;
+  padding: 0.55rem 0.75rem;
+  min-height: var(--tap-min);
+  background: rgba(240, 253, 250, 0.94);
   border-bottom: 1px solid var(--border);
-  box-shadow: var(--shadow-sm);
-  margin: -1rem -1rem 1.25rem -1rem;
+  backdrop-filter: blur(8px);
 }
 
-.back-btn {
-  flex: 0 0 auto;
-  text-align: right;
-  background: none;
-  border: none;
-  font-size: 0.95rem;
-  cursor: pointer;
-  color: var(--brand);
-  font-weight: 700;
-  padding: 0.35rem 0.25rem;
-}
-
-.page-title {
-  flex: 1;
-  text-align: center;
+.gc-nav h1 {
   margin: 0;
-  font-size: clamp(1.1rem, 3vw, 1.45rem);
-  color: var(--brand-deep);
-  font-family: var(--font-display);
-}
-
-.nav-placeholder {
-  width: 4.5rem;
-}
-
-.page-actions {
   text-align: center;
-  margin-bottom: 1.25rem;
+  font-size: 1.05rem;
+  color: var(--brand-deep);
 }
 
-.add-data-btn {
-  background-color: var(--brand);
-  color: var(--text-on-brand);
-  padding: 0.8rem 1.4rem;
+.gc-back,
+.gc-nav-add {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  min-height: var(--tap-min);
+  min-width: var(--tap-min);
+  padding: 0.4rem 0.55rem;
   border: none;
   border-radius: 10px;
-  cursor: pointer;
-  font-size: 1rem;
-  font-weight: 700;
-  transition: background-color 0.2s ease;
-}
-
-.add-data-btn:hover {
-  background-color: var(--brand-deep);
-}
-
-.age-now-label {
-  margin: 0.7rem 0 0;
-  color: var(--ink-muted);
-  font-size: 0.92rem;
-}
-
-.age-now-label strong {
-  color: var(--brand-deep);
-}
-
-.chart-info-boxes {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.85rem;
-  margin-bottom: 1.25rem;
-}
-
-.info-box {
-  background-color: var(--surface);
-  padding: 1rem 0.9rem 1.1rem;
-  border-radius: var(--radius-md);
-  text-align: center;
-  box-shadow: var(--shadow-sm);
-  border: 1px solid var(--border);
-  border-inline-start-width: 5px;
-}
-
-.info-box h4 {
-  margin: 0 0 0.45rem 0;
-  color: #3f4f4d;
-  font-size: 0.92rem;
-  font-weight: 700;
-}
-
-.info-box p {
-  margin: 0 0 0.4rem 0;
-  font-size: clamp(1.35rem, 3vw, 1.6rem);
-  font-weight: 800;
-  color: #102a27;
-  font-family: var(--font-display);
-  line-height: 1.25;
-}
-
-.info-box .info-meta {
-  display: flex;
-  flex-direction: column;
-  gap: 0.12rem;
-  margin: 0 0 0.65rem 0;
-  color: #3f4f4d;
-  font-size: 0.84rem;
-  font-weight: 600;
-  line-height: 1.45;
-}
-
-.info-box .status-label {
-  display: inline-block;
-  font-size: 0.86rem;
-  font-weight: 700;
-  padding: 0.3rem 0.75rem;
-  border-radius: 999px;
-  line-height: 1.4;
-  color: #fff;
-}
-
-.info-box.growth-status-normal { border-inline-start-color: #047857; background: #fff; }
-.info-box.growth-status-low { border-inline-start-color: #b45309; background: #fff; }
-.info-box.growth-status-high { border-inline-start-color: #b91c1c; background: #fff; }
-.info-box.growth-status-unknown { border-inline-start-color: #6b7280; background: #fff; }
-
-.info-box.growth-status-normal .status-label { background-color: #047857; }
-.info-box.growth-status-low .status-label { background-color: #b45309; }
-.info-box.growth-status-high .status-label { background-color: #b91c1c; }
-.info-box.growth-status-unknown .status-label { background-color: #6b7280; }
-
-.chart-section,
-.history-section {
-  background-color: var(--surface);
-  padding: 1.25rem;
-  border-radius: var(--radius-md);
-  border: 1px solid var(--border);
-  box-shadow: var(--shadow-sm);
-  margin-bottom: 1.25rem;
-}
-
-.chart-section h3,
-.history-section h3 {
-  text-align: center;
-  margin: 0 0 0.5rem;
-  color: var(--brand-deep);
-  font-family: var(--font-display);
-}
-
-.chart-hint {
-  text-align: center;
-  margin: 0 0 1rem;
-  color: var(--ink-muted);
-  font-size: 0.86rem;
-}
-
-.custom-legend {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 0.65rem 1rem;
-}
-
-.custom-legend li {
-  cursor: help;
-  font-size: 0.88rem;
-  font-weight: 600;
-}
-
-.history-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  gap: 0.75rem;
-  margin-bottom: 0.9rem;
-}
-
-.history-header h3 {
-  text-align: right;
-  margin: 0;
-}
-
-.history-header span {
-  color: var(--ink-muted);
-  font-size: 0.88rem;
-  font-weight: 600;
-}
-
-.history-empty {
-  text-align: center;
-  color: var(--ink-muted);
-  margin: 0.5rem 0;
-}
-
-.history-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.7rem;
-}
-
-.history-item {
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  background: #fff;
-  overflow: hidden;
-}
-
-.history-item-main {
-  width: 100%;
-  border: none;
   background: transparent;
-  text-align: right;
-  padding: 0.85rem 0.95rem;
-  cursor: pointer;
-  color: inherit;
-}
-
-.history-item-title {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.75rem;
-  margin-bottom: 0.45rem;
-}
-
-.history-item-title strong {
-  color: var(--brand-deep);
-  font-size: 1rem;
-}
-
-.history-item-title span {
-  color: var(--ink-muted);
-  font-size: 0.86rem;
-  font-weight: 600;
-}
-
-.history-item-summary {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.35rem;
-  color: #334155;
-  font-size: 0.86rem;
-  font-weight: 600;
-}
-
-.history-item-detail {
-  border-top: 1px solid var(--border);
-  padding: 0.85rem 0.95rem 1rem;
-  background: var(--surface-2);
-}
-
-.history-item-detail p {
-  margin: 0 0 0.55rem;
-  color: var(--ink);
-  font-size: 0.92rem;
-}
-
-.history-item-detail ul {
-  margin: 0 0 0.85rem;
-  padding-right: 1.1rem;
-  color: #334155;
-}
-
-.history-item-detail li {
-  margin-bottom: 0.25rem;
-}
-
-.history-item-actions {
-  display: flex;
-  gap: 0.6rem;
-}
-
-.btn-edit,
-.btn-delete {
-  border: none;
-  border-radius: 8px;
-  padding: 0.55rem 0.9rem;
+  color: var(--brand);
   font-weight: 700;
+  font-size: 0.88rem;
   cursor: pointer;
-  font-size: 0.9rem;
 }
 
-.btn-edit {
+.gc-nav-add {
   background: var(--brand);
   color: #fff;
 }
 
-.btn-delete {
+.gc-hero {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.95rem 1rem;
+  margin-bottom: 0.85rem;
+  border-radius: var(--radius-md);
+  background: linear-gradient(145deg, #0f766e 0%, #115e59 70%, #0b3d3a 100%);
+  color: #fff;
+  box-shadow: var(--shadow-md);
+}
+
+.gc-hero-icon {
+  width: 48px;
+  height: 48px;
+  flex: 0 0 48px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.14);
+  font-size: 1.25rem;
+}
+
+.gc-hero-text h2 {
+  margin: 0.1rem 0 0.25rem;
+  color: #fff;
+  font-size: 1.2rem;
+}
+
+.gc-kicker {
+  margin: 0;
+  opacity: 0.78;
+  font-size: 0.78rem;
+}
+
+.gc-hero-meta {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 0.4rem;
+  font-size: 0.86rem;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.gc-hero-meta span {
+  opacity: 0.5;
+}
+
+.gc-tabs {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.45rem;
+  margin-bottom: 0.85rem;
+}
+
+.gc-tab {
+  min-height: 58px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+  color: var(--ink);
+  padding: 0.45rem 0.35rem;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.1rem;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.gc-tab strong {
+  font-size: 0.92rem;
+}
+
+.gc-tab span {
+  font-size: 0.74rem;
+  color: var(--ink-muted);
+  font-weight: 600;
+}
+
+.gc-tab.is-active {
+  background: var(--brand);
+  border-color: var(--brand);
+  color: #fff;
+}
+
+.gc-tab.is-active span {
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.gc-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  padding: 0.95rem 0.9rem;
+  margin-bottom: 0.85rem;
+}
+
+.gc-metric-card {
+  border-inline-start-width: 5px;
+}
+
+.gc-metric-card.is-ok { border-inline-start-color: #047857; }
+.gc-metric-card.is-low { border-inline-start-color: #b45309; }
+.gc-metric-card.is-high { border-inline-start-color: #b91c1c; }
+.gc-metric-card.is-muted { border-inline-start-color: #6b7280; }
+
+.gc-metric-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.gc-metric-label {
+  margin: 0;
+  color: var(--ink-muted);
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+.gc-metric-value {
+  margin: 0.2rem 0 0;
+  font-size: 1.7rem;
+  font-weight: 800;
+  font-family: var(--font-display);
+  line-height: 1.1;
+  color: var(--ink);
+}
+
+.gc-metric-value span {
+  margin-right: 0.3rem;
+  font-size: 0.95rem;
+  color: var(--ink-muted);
+}
+
+.gc-metric-badges {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+}
+
+.gc-status,
+.gc-percentile {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0.15rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.gc-status.is-ok { background: #047857; color: #fff; }
+.gc-status.is-low { background: #b45309; color: #fff; }
+.gc-status.is-high { background: #b91c1c; color: #fff; }
+.gc-status.is-muted { background: #6b7280; color: #fff; }
+
+.gc-percentile {
+  background: var(--brand-soft);
+  color: var(--brand-deep);
+}
+
+.gc-metric-facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.7rem;
+  margin: 0.7rem 0 0.55rem;
+  color: #3f4f4d;
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.gc-metric-note {
+  margin: 0;
+  color: var(--ink);
+  font-size: 0.9rem;
+  line-height: 1.7;
+}
+
+.gc-banner {
+  margin: 0 0 0.85rem;
+  padding: 0.7rem 0.85rem;
+  border-radius: 12px;
+  background: var(--warning-soft);
+  color: #92400e;
+  font-size: 0.86rem;
+  font-weight: 600;
+}
+
+.gc-chart-head {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  margin-bottom: 0.45rem;
+}
+
+.gc-chart-head h3 {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 1rem;
+  color: var(--brand-deep);
+}
+
+.gc-range-toggle {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.4rem;
+  background: var(--surface-2);
+  padding: 0.25rem;
+  border-radius: 12px;
+}
+
+.gc-range-toggle button {
+  min-height: 40px;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--ink-muted);
+  font-weight: 700;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.gc-range-toggle button.is-active {
+  background: #fff;
+  color: var(--brand-deep);
+  box-shadow: var(--shadow-sm);
+}
+
+.gc-chart-hint,
+.gc-axis-caption {
+  margin: 0 0 0.7rem;
+  color: var(--ink-muted);
+  font-size: 0.8rem;
+  line-height: 1.6;
+}
+
+.gc-axis-caption {
+  margin: 0.35rem 0 0;
+  text-align: center;
+}
+
+.gc-chart-wrap {
+  width: 100%;
+  overflow: hidden;
+}
+
+.gc-tooltip {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.5rem 0.65rem;
+  box-shadow: var(--shadow-md);
+  font-size: 0.78rem;
+  max-width: 180px;
+}
+
+.gc-tooltip p {
+  margin: 0.15rem 0;
+}
+
+.gc-tooltip-age {
+  font-weight: 700;
+  color: var(--brand-deep);
+}
+
+.gc-selected {
+  margin-top: 0.7rem;
+  padding: 0.7rem 0.8rem;
+  border-radius: 12px;
+  background: #fff1f2;
+  border: 1px solid #fecdd3;
+}
+
+.gc-selected strong {
+  display: block;
+  color: #9f1239;
+  font-size: 0.82rem;
+  margin-bottom: 0.2rem;
+}
+
+.gc-selected p {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.gc-empty {
+  text-align: center;
+  padding: 1.1rem 0.4rem 0.4rem;
+  color: var(--ink-muted);
+}
+
+.gc-empty p {
+  margin: 0 0 0.8rem;
+}
+
+.gc-primary-btn,
+.gc-ghost-btn,
+.gc-btn-edit,
+.gc-btn-delete {
+  min-height: var(--tap-min);
+  border: none;
+  border-radius: 10px;
+  font-weight: 700;
+  cursor: pointer;
+  padding: 0.65rem 0.9rem;
+}
+
+.gc-primary-btn {
+  background: var(--brand);
+  color: #fff;
+}
+
+.gc-ghost-btn {
+  background: #eef2f1;
+  color: #334155;
+}
+
+.gc-accordion {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.6rem;
+  min-height: var(--tap-min);
+  margin-top: 0.55rem;
+  padding: 0.35rem 0.15rem;
+  border: none;
+  background: transparent;
+  color: var(--brand-deep);
+  font-weight: 700;
+  font-size: 0.92rem;
+  cursor: pointer;
+}
+
+.gc-accordion span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.gc-accordion svg {
+  transition: transform 0.2s ease;
+}
+
+.gc-accordion.is-open svg:last-child {
+  transform: rotate(180deg);
+}
+
+.gc-legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.gc-legend li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+}
+
+.gc-legend i {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  margin-top: 0.35rem;
+  flex: 0 0 12px;
+}
+
+.gc-legend strong {
+  display: block;
+  font-size: 0.88rem;
+}
+
+.gc-legend p {
+  margin: 0.1rem 0 0;
+  color: var(--ink-muted);
+  font-size: 0.8rem;
+  line-height: 1.55;
+}
+
+.gc-guide p {
+  margin: 0 0 0.65rem;
+  font-size: 0.9rem;
+  line-height: 1.75;
+}
+
+.gc-guide p:last-child {
+  margin-bottom: 0;
+}
+
+.gc-history-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.6rem;
+  margin-bottom: 0.75rem;
+}
+
+.gc-history-head h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--brand-deep);
+}
+
+.gc-history-head span {
+  color: var(--ink-muted);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.gc-history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.gc-history-item {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.gc-history-main {
+  width: 100%;
+  border: none;
+  background: transparent;
+  text-align: right;
+  padding: 0.8rem 0.85rem;
+  cursor: pointer;
+  color: inherit;
+}
+
+.gc-history-title {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.6rem;
+  margin-bottom: 0.4rem;
+}
+
+.gc-history-title strong {
+  color: var(--brand-deep);
+}
+
+.gc-history-title span,
+.gc-history-p {
+  color: var(--ink-muted);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.gc-history-summary {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.25rem;
+  font-size: 0.84rem;
+  font-weight: 600;
+  color: #334155;
+}
+
+.gc-history-summary .is-focus {
+  color: var(--brand-deep);
+}
+
+.gc-history-p {
+  margin: 0.4rem 0 0;
+}
+
+.gc-history-detail {
+  border-top: 1px solid var(--border);
+  padding: 0.8rem 0.85rem 0.95rem;
+  background: var(--surface-2);
+}
+
+.gc-history-detail p {
+  margin: 0 0 0.7rem;
+  font-size: 0.9rem;
+}
+
+.gc-history-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+}
+
+.gc-btn-edit {
+  background: var(--brand);
+  color: #fff;
+}
+
+.gc-btn-delete {
   background: #fee2e2;
   color: #991b1b;
 }
 
-.growth-modal-overlay {
+.gc-fab {
+  display: none;
+}
+
+.gc-modal-overlay {
   position: fixed;
   inset: 0;
   background: rgba(15, 61, 58, 0.55);
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-end;
   z-index: 2200;
-  padding: 1rem;
+  padding: 0;
 }
 
-.add-data-modal {
+.gc-modal {
   background: #fff;
-  padding: 1.4rem 1.25rem 1.25rem;
-  border-radius: 14px;
-  width: min(100%, 420px);
-  max-height: min(92vh, 720px);
+  width: 100%;
+  max-height: min(92vh, 740px);
   overflow: auto;
   outline: none;
-  box-shadow: 0 16px 40px rgba(15, 61, 58, 0.22);
-  border: 1px solid var(--border);
+  border-radius: 18px 18px 0 0;
+  padding: 1.15rem 1rem 1.25rem;
+  box-shadow: 0 -12px 32px rgba(15, 61, 58, 0.2);
 }
 
-.add-data-modal h2 {
+.gc-modal h2 {
   text-align: center;
-  margin: 0 0 1rem;
+  margin: 0 0 0.9rem;
+  font-size: 1.15rem;
   color: var(--brand-deep);
-  font-family: var(--font-display);
-  font-size: 1.2rem;
 }
 
-.add-data-form {
+.gc-form {
   display: flex;
   flex-direction: column;
-  gap: 0.45rem;
+  gap: 0.4rem;
 }
 
-.field-label {
-  font-size: 0.86rem;
+.gc-field-label {
+  font-size: 0.84rem;
   font-weight: 700;
   color: #3f4f4d;
-  margin-top: 0.35rem;
+  margin-top: 0.3rem;
 }
 
-.add-data-form input,
-.add-data-form .form-control {
-  padding: 0.75rem 0.8rem;
+.gc-input {
+  padding: 0.8rem 0.85rem;
   border: 1px solid var(--border-strong);
   border-radius: 10px;
   width: 100%;
@@ -361,114 +619,95 @@
   background: #fff;
 }
 
-.growth-datepicker {
+.gc-datepicker {
   width: 100%;
   z-index: 2300;
 }
 
-.growth-datepicker .rmdp-wrapper,
+.gc-datepicker .rmdp-wrapper,
 .rmdp-calendar-container,
 .rmdp-container {
   z-index: 2301 !important;
 }
 
-.form-error {
-  margin: 0.85rem 0 0;
+.gc-form-error {
+  margin: 0.8rem 0 0;
   color: #b91c1c;
   background: #fee2e2;
   border-radius: 8px;
   padding: 0.55rem 0.7rem;
-  font-size: 0.9rem;
+  font-size: 0.88rem;
   font-weight: 600;
 }
 
-.modal-actions {
-  display: flex;
-  gap: 0.7rem;
-  margin-top: 1.1rem;
+.gc-modal-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.6rem;
+  margin-top: 1rem;
 }
 
-.modal-actions button {
-  flex: 1;
-  padding: 0.75rem;
-  border: none;
-  border-radius: 10px;
-  font-size: 0.98rem;
-  font-weight: 700;
-  cursor: pointer;
-}
-
-.modal-actions button:first-child {
-  background-color: var(--brand);
-  color: var(--text-on-brand);
-}
-
-.modal-actions button:last-child {
-  background-color: #eef2f1;
-  color: #334155;
-}
-
-.modal-actions button:disabled {
+.gc-modal-actions button:disabled {
   opacity: 0.65;
   cursor: not-allowed;
 }
 
-@media (max-width: 900px) {
-  .chart-info-boxes {
-    grid-template-columns: 1fr;
+@media (min-width: 769px) {
+  .growth-chart-page {
+    max-width: 860px;
+    padding-bottom: 2.5rem;
   }
 
-  .history-item-summary {
-    grid-template-columns: 1fr;
+  .gc-nav {
+    margin: 0 0 1rem;
+    border-radius: 0 0 12px 12px;
+  }
+
+  .gc-tabs {
+    gap: 0.65rem;
+  }
+
+  .gc-history-summary {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .gc-modal-overlay {
+    align-items: center;
+    padding: 1rem;
+  }
+
+  .gc-modal {
+    width: min(100%, 440px);
+    border-radius: 16px;
+    max-height: min(90vh, 720px);
+  }
+
+  .gc-fab {
+    display: none;
   }
 }
 
 @media (max-width: 768px) {
-  .growth-chart-page {
-    padding: 0.65rem;
+  .gc-fab {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.45rem;
+    position: fixed;
+    left: 0.85rem;
+    right: 0.85rem;
+    bottom: calc(72px + env(safe-area-inset-bottom, 0px));
+    z-index: 1400;
+    min-height: 48px;
+    border: none;
+    border-radius: 14px;
+    background: var(--brand);
+    color: #fff;
+    font-weight: 800;
+    box-shadow: 0 10px 24px rgba(15, 118, 110, 0.28);
   }
 
-  .page-nav-final {
-    margin: -0.65rem -0.65rem 1rem -0.65rem;
-    padding: 0.7rem 0.8rem;
-  }
-
-  .nav-placeholder {
+  .gc-back span {
     display: none;
-  }
-
-  .back-btn {
-    font-size: 0.88rem;
-  }
-
-  .page-title {
-    font-size: 1.05rem;
-  }
-
-  .chart-section,
-  .history-section {
-    padding: 0.85rem;
-  }
-
-  .recharts-text {
-    font-size: 0.75em;
-  }
-
-  .custom-legend {
-    font-size: 0.82rem;
-  }
-
-  .add-data-modal {
-    width: 100%;
-    padding: 1.15rem 0.95rem 1rem;
-  }
-
-  .history-item-actions {
-    flex-direction: column;
-  }
-
-  .btn-edit,
-  .btn-delete {
-    width: 100%;
   }
 }

--- a/client/src/components/GrowthChartPage.js
+++ b/client/src/components/GrowthChartPage.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import {
-    LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine
+    ComposedChart, Area, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine
 } from 'recharts';
 import DatePicker from 'react-multi-date-picker';
 import DateObject from 'react-date-object';
@@ -33,7 +33,7 @@ import {
     ageInMonths, formatLocalDate, normalizeDateString,
     parseLocalDate, formatAgeLabel
 } from '../utils/growth-dates';
-import { buildChartData, getVisibleAgeDomain, buildAgeTicks, formatDelta } from '../utils/growth-chart-helpers';
+import { buildChartData, getVisibleAgeDomain, buildAgeTicks, formatDelta, getYDomain } from '../utils/growth-chart-helpers';
 import { toShamsi } from '../utils/dateConverter';
 import { getChildDisplayName } from '../utils/childName';
 import './GrowthChartPage.css';
@@ -144,23 +144,17 @@ const GrowthChart = ({
     });
     const visibleData = chartData.filter((row) => row.month >= minAge - 0.01 && row.month <= maxAge + 0.01);
     const ageMarker = Math.min(Math.max(childAgeInMonths || 0, minAge), maxAge);
-    const values = visibleData
-        .flatMap((row) => [row.P3, row.P50, row.P97, row.value])
-        .filter((value) => value != null && !Number.isNaN(value));
-    const minValue = values.length ? Math.min(...values) : 0;
-    const maxValue = values.length ? Math.max(...values) : 1;
-    const padding = Math.max((maxValue - minValue) * 0.1, 1);
-    const yDomain = [Math.max(0, Math.floor(minValue - padding)), Math.ceil(maxValue + padding)];
+    const yDomain = getYDomain(visibleData);
     const ticks = buildAgeTicks(minAge, maxAge);
     const isNarrow = typeof window !== 'undefined' && window.innerWidth <= 768;
-    const chartHeight = isNarrow ? 240 : 320;
+    const chartHeight = isNarrow ? 300 : 360;
 
     return (
         <div className="gc-chart-wrap">
             <ResponsiveContainer width="100%" height={chartHeight}>
-                <LineChart
+                <ComposedChart
                     data={visibleData}
-                    margin={{ top: 12, right: 8, left: 0, bottom: 4 }}
+                    margin={{ top: 16, right: 10, left: 0, bottom: 8 }}
                     onClick={(state) => {
                         const point = state?.activePayload?.[0]?.payload;
                         if (point?.value != null) onSelectPoint(point);
@@ -174,11 +168,11 @@ const GrowthChart = ({
                         ticks={ticks}
                         allowDecimals
                         tick={{ fontSize: 11, fill: '#5b716e' }}
-                        tickMargin={6}
+                        tickMargin={8}
                     />
                     <YAxis
                         domain={yDomain}
-                        width={isNarrow ? 36 : 44}
+                        width={isNarrow ? 38 : 46}
                         tick={{ fontSize: 11, fill: '#5b716e' }}
                         tickMargin={4}
                     />
@@ -186,19 +180,20 @@ const GrowthChart = ({
                         content={<CustomTooltip childName={childName} />}
                         allowEscapeViewBox={{ x: true, y: true }}
                     />
-                    <Line type="monotone" dataKey="P3" stroke="#d97706" name="صدک ۳" dot={false} strokeWidth={1.5} connectNulls isAnimationActive={false} />
-                    <Line type="monotone" dataKey="P50" stroke="#0f766e" name="صدک ۵۰" dot={false} strokeWidth={2} connectNulls isAnimationActive={false} />
-                    <Line type="monotone" dataKey="P97" stroke="#0284c7" name="صدک ۹۷" dot={false} strokeWidth={1.5} connectNulls isAnimationActive={false} />
+                    <Area type="monotone" dataKey="P97" stroke="none" fill="#99f6e4" fillOpacity={0.28} connectNulls isAnimationActive={false} />
+                    <Line type="monotone" dataKey="P3" stroke="#d97706" name="صدک ۳" dot={false} strokeWidth={1.6} connectNulls isAnimationActive={false} />
+                    <Line type="monotone" dataKey="P50" stroke="#0f766e" name="صدک ۵۰" dot={false} strokeWidth={2.2} connectNulls isAnimationActive={false} />
+                    <Line type="monotone" dataKey="P97" stroke="#0284c7" name="صدک ۹۷" dot={false} strokeWidth={1.6} connectNulls isAnimationActive={false} />
                     <Line
                         type="monotone"
                         dataKey="value"
                         stroke="#dc2626"
                         name={childName}
-                        strokeWidth={2.5}
+                        strokeWidth={2.6}
                         connectNulls
                         isAnimationActive={false}
-                        dot={{ r: isNarrow ? 5 : 4, strokeWidth: 2, fill: '#fff', stroke: '#dc2626' }}
-                        activeDot={{ r: 7 }}
+                        dot={{ r: isNarrow ? 6 : 5, strokeWidth: 2, fill: '#fff', stroke: '#dc2626' }}
+                        activeDot={{ r: 8 }}
                     />
                     {childAgeInMonths > 0 && (
                         <ReferenceLine
@@ -210,7 +205,7 @@ const GrowthChart = ({
                     {selectedMonth != null && (
                         <ReferenceLine x={selectedMonth} stroke="#dc2626" strokeDasharray="2 4" />
                     )}
-                </LineChart>
+                </ComposedChart>
             </ResponsiveContainer>
             <p className="gc-axis-caption">محور افقی: سن (ماه) · محور عمودی: {yAxisLabel}</p>
         </div>
@@ -477,44 +472,6 @@ const GrowthChartPage = () => {
                 })}
             </div>
 
-            <section className={`gc-card gc-metric-card ${statusClass(activeAnalysis.status)}`}>
-                <div className="gc-metric-top">
-                    <div>
-                        <p className="gc-metric-label">آخرین {activeMeta.label}</p>
-                        <p className="gc-metric-value">
-                            {activeAnalysis.value != null ? (
-                                <>
-                                    {activeAnalysis.value}
-                                    <span>{activeMeta.unit}</span>
-                                </>
-                            ) : '—'}
-                        </p>
-                    </div>
-                    <div className="gc-metric-badges">
-                        <span className={`gc-status ${statusClass(activeAnalysis.status)}`}>
-                            {activeAnalysis.status}
-                        </span>
-                        {percentile != null && (
-                            <span className="gc-percentile">صدک {percentile}</span>
-                        )}
-                    </div>
-                </div>
-                <div className="gc-metric-facts">
-                    {activeAnalysis.date ? (
-                        <span>تاریخ: {toShamsi(activeAnalysis.date)}</span>
-                    ) : (
-                        <span>هنوز اندازه‌گیری ثبت نشده</span>
-                    )}
-                    {activeAnalysis.ageInMonths != null && (
-                        <span>سن ثبت: {formatAgeLabel(activeAnalysis.ageInMonths)}</span>
-                    )}
-                    <span>روند: {trend.label}</span>
-                    {deltaLabel && <span>تغییر: {deltaLabel}</span>}
-                    <span>{activeAnalysis.count} نقطه روی نمودار</span>
-                </div>
-                <p className="gc-metric-note">{getGrowthInterpretation(activeMetric, activeAnalysis)}</p>
-            </section>
-
             {beyondWho && (
                 <p className="gc-banner">
                     منحنی استاندارد سازمان بهداشت جهانی تا ۵ سالگی است. برای سن بالاتر، نقاط روی انتهای نمودار نمایش داده می‌شوند.
@@ -568,6 +525,15 @@ const GrowthChartPage = () => {
                     />
                 )}
 
+                <ul className="gc-legend-chips" aria-label="راهنمای رنگ نمودار">
+                    {legendItems.map((item) => (
+                        <li key={item.label}>
+                            <i style={{ background: item.color }} />
+                            {item.label}
+                        </li>
+                    ))}
+                </ul>
+
                 {selectedPoint && (
                     <div className="gc-selected">
                         <strong>نقطه انتخاب‌شده</strong>
@@ -584,7 +550,7 @@ const GrowthChartPage = () => {
                     className={`gc-accordion ${legendOpen ? 'is-open' : ''}`}
                     onClick={() => setLegendOpen((open) => !open)}
                 >
-                    <span>راهنمای خطوط نمودار</span>
+                    <span>توضیح خطوط صدک</span>
                     <FontAwesomeIcon icon={faChevronDown} />
                 </button>
                 {legendOpen && (
@@ -600,6 +566,44 @@ const GrowthChartPage = () => {
                         ))}
                     </ul>
                 )}
+            </section>
+
+            <section className={`gc-card gc-metric-card ${statusClass(activeAnalysis.status)}`}>
+                <div className="gc-metric-top">
+                    <div>
+                        <p className="gc-metric-label">آخرین {activeMeta.label}</p>
+                        <p className="gc-metric-value">
+                            {activeAnalysis.value != null ? (
+                                <>
+                                    {activeAnalysis.value}
+                                    <span>{activeMeta.unit}</span>
+                                </>
+                            ) : '—'}
+                        </p>
+                    </div>
+                    <div className="gc-metric-badges">
+                        <span className={`gc-status ${statusClass(activeAnalysis.status)}`}>
+                            {activeAnalysis.status}
+                        </span>
+                        {percentile != null && (
+                            <span className="gc-percentile">صدک {percentile}</span>
+                        )}
+                    </div>
+                </div>
+                <div className="gc-metric-facts">
+                    {activeAnalysis.date ? (
+                        <span>تاریخ: {toShamsi(activeAnalysis.date)}</span>
+                    ) : (
+                        <span>هنوز اندازه‌گیری ثبت نشده</span>
+                    )}
+                    {activeAnalysis.ageInMonths != null && (
+                        <span>سن ثبت: {formatAgeLabel(activeAnalysis.ageInMonths)}</span>
+                    )}
+                    <span>روند: {trend.label}</span>
+                    {deltaLabel && <span>تغییر: {deltaLabel}</span>}
+                    <span>{activeAnalysis.count} نقطه روی نمودار</span>
+                </div>
+                <p className="gc-metric-note">{getGrowthInterpretation(activeMetric, activeAnalysis)}</p>
             </section>
 
             <section className="gc-card gc-history-card">

--- a/client/src/components/GrowthChartPage.js
+++ b/client/src/components/GrowthChartPage.js
@@ -1,8 +1,7 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import {
-    LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend,
-    ResponsiveContainer, ReferenceLine
+    LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine
 } from 'recharts';
 import DatePicker from 'react-multi-date-picker';
 import DateObject from 'react-date-object';
@@ -10,12 +9,31 @@ import persian from 'react-date-object/calendars/persian';
 import gregorian from 'react-date-object/calendars/gregorian';
 import persian_fa from 'react-date-object/locales/persian_fa';
 import Modal from 'react-modal';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+    faArrowRight,
+    faPlus,
+    faChild,
+    faInfoCircle,
+    faChevronDown,
+    faPen,
+    faTrash,
+    faChartLine,
+} from '@fortawesome/free-solid-svg-icons';
 import { whoStats } from '../who-stats';
-import { analyzeGrowthMetric } from '../utils/growth-analyzer';
+import {
+    analyzeGrowthMetric,
+    analyzeRecordMetric,
+    getGrowthInterpretation,
+    getTrendMeta,
+    roundPercentile,
+    METRIC_META,
+} from '../utils/growth-analyzer';
 import {
     ageInMonths, formatLocalDate, normalizeDateString,
-    parseLocalDate, roundAgeMonths, formatAgeLabel
+    parseLocalDate, formatAgeLabel
 } from '../utils/growth-dates';
+import { buildChartData, getVisibleAgeDomain, buildAgeTicks, formatDelta } from '../utils/growth-chart-helpers';
 import { toShamsi } from '../utils/dateConverter';
 import { getChildDisplayName } from '../utils/childName';
 import './GrowthChartPage.css';
@@ -25,11 +43,18 @@ Modal.setAppElement('#root');
 
 const emptyForm = { date: null, height: '', weight: '', headCircumference: '' };
 
-const legendTooltips = {
-    'صدک ۳': '۳٪ از کودکان هم‌سن و هم‌جنس، مقداری کمتر از این خط دارند.',
-    'صدک ۵۰ (میانه)': 'نقطه میانی رشد؛ ۵۰٪ از کودکان مقداری کمتر و ۵۰٪ مقداری بیشتر از این خط دارند.',
-    'صدک ۹۷': '۹۷٪ از کودکان هم‌سن و هم‌جنس، مقداری کمتر از این خط دارند.'
-};
+const METRIC_TABS = [
+    { key: 'height', whoBoys: 'heightForAgeBoys', whoGirls: 'heightForAgeGirls' },
+    { key: 'weight', whoBoys: 'weightForAgeBoys', whoGirls: 'weightForAgeGirls' },
+    { key: 'headCircumference', whoBoys: 'headCircumferenceForAgeBoys', whoGirls: 'headCircumferenceForAgeGirls' },
+];
+
+const legendItems = [
+    { color: '#d97706', label: 'صدک ۳', hint: '۳٪ از کودکان هم‌سن و هم‌جنس مقداری کمتر از این خط دارند.' },
+    { color: '#0f766e', label: 'صدک ۵۰', hint: 'نقطه میانی رشد؛ نیمی از کودکان پایین‌تر و نیمی بالاتر از این خط هستند.' },
+    { color: '#0284c7', label: 'صدک ۹۷', hint: '۹۷٪ از کودکان هم‌سن و هم‌جنس مقداری کمتر از این خط دارند.' },
+    { color: '#dc2626', label: 'کودک شما', hint: 'نقاط قرمز اندازه‌گیری‌های ثبت‌شده روی محور سن هستند.' },
+];
 
 const toGregorianDateString = (value) => {
     if (!value) return '';
@@ -40,7 +65,6 @@ const toGregorianDateString = (value) => {
             return formatLocalDate(selected);
         }
 
-        // react-multi-date-picker DateObject (possibly Persian calendar)
         if (typeof selected === 'object') {
             let jsDate = null;
             if (typeof selected.toDate === 'function') {
@@ -56,12 +80,10 @@ const toGregorianDateString = (value) => {
         }
 
         if (typeof selected === 'string') {
-            // If string is already gregorian-like
             const normalized = normalizeDateString(selected);
             if (normalized && Number(normalized.slice(0, 4)) > 1700) {
                 return normalized;
             }
-            // Persian date string → gregorian
             const persianDate = new DateObject({
                 date: selected.replace(/-/g, '/'),
                 format: 'YYYY/MM/DD',
@@ -75,133 +97,125 @@ const toGregorianDateString = (value) => {
     return '';
 };
 
-const CustomLegend = ({ payload, childName }) => (
-    <ul className="custom-legend">
-        {(payload || []).map((entry, index) => {
-            const isChild = entry.value === childName;
-            return (
-                <li key={`legend-${index}`} style={{ color: entry.color }} title={legendTooltips[entry.value] || ''}>
-                    {isChild ? `${entry.value} (داده‌های شما)` : entry.value}
-                </li>
-            );
-        })}
-    </ul>
-);
-
-const buildChartData = (standardData, childPoints) => {
-    const rows = (standardData || []).map((row) => ({
-        month: row.month,
-        P3: row.P3,
-        P50: row.P50,
-        P97: row.P97,
-        value: null,
-        recordDate: null,
-    }));
-
-    (childPoints || []).forEach((point) => {
-        if (point.month == null || point.value == null || Number.isNaN(point.month)) return;
-        const month = roundAgeMonths(Math.max(0, point.month), 2);
-        rows.push({
-            month,
-            P3: null,
-            P50: null,
-            P97: null,
-            value: point.value,
-            recordDate: point.date || null,
-        });
-    });
-
-    return rows.sort((a, b) => a.month - b.month);
+const statusClass = (status) => {
+    if (status === 'کمبود') return 'is-low';
+    if (status === 'اضافه') return 'is-high';
+    if (status === 'نرمال') return 'is-ok';
+    return 'is-muted';
 };
 
-const GrowthChart = ({ data, standardData, childName, yAxisLabel, childAgeInMonths }) => {
-    const chartData = buildChartData(standardData, data);
-    const maxAge = Math.max(60, Math.ceil((childAgeInMonths || 0) + 1));
-    const ageMarker = Math.min(Math.max(childAgeInMonths || 0, 0), maxAge);
-    const values = chartData
-        .flatMap((row) => [row.P3, row.P50, row.P97, row.value])
-        .filter((v) => v != null && !Number.isNaN(v));
-    const minValue = values.length ? Math.min(...values) : 0;
-    const maxValue = values.length ? Math.max(...values) : 1;
-    const padding = Math.max((maxValue - minValue) * 0.08, 1);
-    const yDomain = [Math.max(0, Math.floor(minValue - padding)), Math.ceil(maxValue + padding)];
-    const ticks = [0, 6, 12, 18, 24, 36, 48, 60].filter((t) => t <= maxAge);
-    if (maxAge > 60 && !ticks.includes(maxAge)) ticks.push(maxAge);
+const CustomTooltip = ({ active, payload, label, childName }) => {
+    if (!active || !payload || !payload.length) return null;
+    const point = payload[0].payload || {};
+    const rows = payload.filter((entry) => entry.value != null);
+    if (!rows.length) return null;
 
     return (
-        <ResponsiveContainer width="100%" height={300}>
-            <LineChart data={chartData} margin={{ top: 20, right: 20, left: 0, bottom: 20 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#d7e5e2" />
-                <XAxis
-                    type="number"
-                    dataKey="month"
-                    domain={[0, maxAge]}
-                    ticks={ticks}
-                    allowDecimals
-                    label={{ value: 'سن (ماه)', position: 'insideBottom', offset: -12 }}
-                />
-                <YAxis
-                    domain={yDomain}
-                    width={42}
-                    label={{ value: yAxisLabel, angle: -90, position: 'insideLeft', offset: 0 }}
-                />
-                <Tooltip
-                    formatter={(value, name) => {
-                        if (value == null) return null;
-                        if (name === childName) return [value, `${childName} (داده شما)`];
-                        return [value, name];
-                    }}
-                    labelFormatter={(label, payload) => {
-                        const point = payload && payload[0] && payload[0].payload;
-                        const ageLabel = `سن: ${Number(label).toFixed(1)} ماه`;
-                        if (point?.recordDate) {
-                            return `${ageLabel} | تاریخ: ${toShamsi(point.recordDate)}`;
-                        }
-                        return ageLabel;
-                    }}
-                />
-                <Legend content={<CustomLegend childName={childName} />} wrapperStyle={{ paddingTop: '16px' }} />
-                <Line type="monotone" dataKey="P3" stroke="#d97706" name="صدک ۳" dot={false} strokeWidth={1.5} connectNulls isAnimationActive={false} />
-                <Line type="monotone" dataKey="P50" stroke="#0f766e" name="صدک ۵۰ (میانه)" dot={false} strokeWidth={2} connectNulls isAnimationActive={false} />
-                <Line type="monotone" dataKey="P97" stroke="#0284c7" name="صدک ۹۷" dot={false} strokeWidth={1.5} connectNulls isAnimationActive={false} />
-                <Line
-                    type="monotone"
-                    dataKey="value"
-                    stroke="#dc2626"
-                    name={childName}
-                    strokeWidth={2.5}
-                    connectNulls
-                    dot={{ r: 4, strokeWidth: 2, fill: '#fff' }}
-                    activeDot={{ r: 6 }}
-                />
-                {childAgeInMonths > 0 && (
-                    <ReferenceLine
-                        x={ageMarker}
-                        stroke="#115e59"
-                        strokeDasharray="4 4"
-                        label={{ value: 'سن فعلی', position: 'insideTopRight', fill: '#115e59', fontSize: 12 }}
-                    />
-                )}
-            </LineChart>
-        </ResponsiveContainer>
+        <div className="gc-tooltip">
+            <p className="gc-tooltip-age">سن: {Number(label).toFixed(1)} ماه</p>
+            {point.recordDate && <p>تاریخ: {toShamsi(point.recordDate)}</p>}
+            {rows.map((entry) => (
+                <p key={entry.dataKey} style={{ color: entry.color }}>
+                    {entry.dataKey === 'value' ? childName : entry.name}: {entry.value}
+                </p>
+            ))}
+        </div>
     );
 };
 
-const MetricInfoCard = ({ title, analysis, unit, statusClassName }) => (
-    <div className={`info-box ${statusClassName}`}>
-        <h4>{title}</h4>
-        <p>{analysis.value != null ? `\u200E${analysis.value} ${unit}` : 'ثبت نشده'}</p>
-        {analysis.date ? (
-            <div className="info-meta">
-                <span>آخرین تاریخ: {toShamsi(analysis.date)}</span>
-                {analysis.ageInMonths != null && <span>سن: {formatAgeLabel(analysis.ageInMonths)}</span>}
-            </div>
-        ) : (
-            <div className="info-meta"><span>هنوز داده‌ای ثبت نشده</span></div>
-        )}
-        <span className="status-label">وضعیت: {analysis.status}</span>
-    </div>
-);
+const GrowthChart = ({
+    data,
+    standardData,
+    childName,
+    yAxisLabel,
+    childAgeInMonths,
+    rangeMode,
+    onSelectPoint,
+    selectedMonth,
+}) => {
+    const chartData = useMemo(
+        () => buildChartData(standardData, data),
+        [standardData, data]
+    );
+    const [minAge, maxAge] = getVisibleAgeDomain({
+        childAgeInMonths,
+        points: data,
+        mode: rangeMode,
+    });
+    const visibleData = chartData.filter((row) => row.month >= minAge - 0.01 && row.month <= maxAge + 0.01);
+    const ageMarker = Math.min(Math.max(childAgeInMonths || 0, minAge), maxAge);
+    const values = visibleData
+        .flatMap((row) => [row.P3, row.P50, row.P97, row.value])
+        .filter((value) => value != null && !Number.isNaN(value));
+    const minValue = values.length ? Math.min(...values) : 0;
+    const maxValue = values.length ? Math.max(...values) : 1;
+    const padding = Math.max((maxValue - minValue) * 0.1, 1);
+    const yDomain = [Math.max(0, Math.floor(minValue - padding)), Math.ceil(maxValue + padding)];
+    const ticks = buildAgeTicks(minAge, maxAge);
+    const isNarrow = typeof window !== 'undefined' && window.innerWidth <= 768;
+    const chartHeight = isNarrow ? 240 : 320;
+
+    return (
+        <div className="gc-chart-wrap">
+            <ResponsiveContainer width="100%" height={chartHeight}>
+                <LineChart
+                    data={visibleData}
+                    margin={{ top: 12, right: 8, left: 0, bottom: 4 }}
+                    onClick={(state) => {
+                        const point = state?.activePayload?.[0]?.payload;
+                        if (point?.value != null) onSelectPoint(point);
+                    }}
+                >
+                    <CartesianGrid strokeDasharray="3 3" stroke="#d7e5e2" />
+                    <XAxis
+                        type="number"
+                        dataKey="month"
+                        domain={[minAge, maxAge]}
+                        ticks={ticks}
+                        allowDecimals
+                        tick={{ fontSize: 11, fill: '#5b716e' }}
+                        tickMargin={6}
+                    />
+                    <YAxis
+                        domain={yDomain}
+                        width={isNarrow ? 36 : 44}
+                        tick={{ fontSize: 11, fill: '#5b716e' }}
+                        tickMargin={4}
+                    />
+                    <Tooltip
+                        content={<CustomTooltip childName={childName} />}
+                        allowEscapeViewBox={{ x: true, y: true }}
+                    />
+                    <Line type="monotone" dataKey="P3" stroke="#d97706" name="صدک ۳" dot={false} strokeWidth={1.5} connectNulls isAnimationActive={false} />
+                    <Line type="monotone" dataKey="P50" stroke="#0f766e" name="صدک ۵۰" dot={false} strokeWidth={2} connectNulls isAnimationActive={false} />
+                    <Line type="monotone" dataKey="P97" stroke="#0284c7" name="صدک ۹۷" dot={false} strokeWidth={1.5} connectNulls isAnimationActive={false} />
+                    <Line
+                        type="monotone"
+                        dataKey="value"
+                        stroke="#dc2626"
+                        name={childName}
+                        strokeWidth={2.5}
+                        connectNulls
+                        isAnimationActive={false}
+                        dot={{ r: isNarrow ? 5 : 4, strokeWidth: 2, fill: '#fff', stroke: '#dc2626' }}
+                        activeDot={{ r: 7 }}
+                    />
+                    {childAgeInMonths > 0 && (
+                        <ReferenceLine
+                            x={ageMarker}
+                            stroke="#115e59"
+                            strokeDasharray="4 4"
+                        />
+                    )}
+                    {selectedMonth != null && (
+                        <ReferenceLine x={selectedMonth} stroke="#dc2626" strokeDasharray="2 4" />
+                    )}
+                </LineChart>
+            </ResponsiveContainer>
+            <p className="gc-axis-caption">محور افقی: سن (ماه) · محور عمودی: {yAxisLabel}</p>
+        </div>
+    );
+};
 
 const GrowthChartPage = () => {
     const history = useHistory();
@@ -214,6 +228,12 @@ const GrowthChartPage = () => {
     const [saving, setSaving] = useState(false);
     const [formError, setFormError] = useState('');
     const [expandedId, setExpandedId] = useState(null);
+    const [activeMetric, setActiveMetric] = useState('height');
+    const [rangeMode, setRangeMode] = useState('focus');
+    const [legendOpen, setLegendOpen] = useState(false);
+    const [guideOpen, setGuideOpen] = useState(false);
+    const [selectedPoint, setSelectedPoint] = useState(null);
+    const [confirmDeleteId, setConfirmDeleteId] = useState(null);
 
     const fetchChildData = useCallback(async () => {
         try {
@@ -236,9 +256,18 @@ const GrowthChartPage = () => {
         fetchChildData();
     }, [fetchChildData]);
 
+    useEffect(() => {
+        setSelectedPoint(null);
+        setExpandedId(null);
+        setConfirmDeleteId(null);
+    }, [activeMetric]);
+
     const openAddModal = () => {
         setEditingRecord(null);
-        setForm(emptyForm);
+        setForm({
+            ...emptyForm,
+            date: new DateObject({ calendar: persian, locale: persian_fa }),
+        });
         setFormError('');
         setModalIsOpen(true);
     };
@@ -254,6 +283,7 @@ const GrowthChartPage = () => {
             headCircumference: record.headCircumference != null ? String(record.headCircumference) : '',
         });
         setFormError('');
+        setConfirmDeleteId(null);
         setModalIsOpen(true);
     };
 
@@ -324,7 +354,6 @@ const GrowthChartPage = () => {
     };
 
     const handleDelete = async (record) => {
-        if (!window.confirm(`رکورد تاریخ ${toShamsi(record.date)} حذف شود؟`)) return;
         try {
             let response;
             if (record.id) {
@@ -341,6 +370,7 @@ const GrowthChartPage = () => {
             }
             const result = await response.json().catch(() => ({}));
             if (!response.ok) throw new Error(result.message || 'حذف ناموفق بود');
+            setConfirmDeleteId(null);
             await fetchChildData();
         } catch (error) {
             alert(error.message);
@@ -350,138 +380,298 @@ const GrowthChartPage = () => {
     if (!child) {
         return (
             <div className="growth-chart-page">
-                <p className="growth-loading">{loadError || 'در حال بارگذاری...'}</p>
+                <p className="gc-loading">{loadError || 'در حال بارگذاری...'}</p>
             </div>
         );
     }
 
     const childName = getChildDisplayName(child);
     const isBoy = child.gender === 'boy';
-
-    const getStatusClassName = (status) => {
-        if (status === 'کمبود') return 'growth-status-low';
-        if (status === 'اضافه') return 'growth-status-high';
-        if (status === 'نرمال') return 'growth-status-normal';
-        return 'growth-status-unknown';
-    };
-
-    const heightAnalysis = analyzeGrowthMetric('height', child);
-    const weightAnalysis = analyzeGrowthMetric('weight', child);
-    const headAnalysis = analyzeGrowthMetric('headCircumference', child);
-
     const birthDate = parseLocalDate(child.birthDate);
     const childAgeInMonths = birthDate ? ageInMonths(new Date(), child.birthDate) : 0;
+    const analyses = {
+        height: analyzeGrowthMetric('height', child),
+        weight: analyzeGrowthMetric('weight', child),
+        headCircumference: analyzeGrowthMetric('headCircumference', child),
+    };
+    const activeMeta = METRIC_META[activeMetric];
+    const activeAnalysis = analyses[activeMetric];
+    const activeTab = METRIC_TABS.find((tab) => tab.key === activeMetric);
+    const standardData = whoStats[isBoy ? activeTab.whoBoys : activeTab.whoGirls];
+    const trend = getTrendMeta(activeAnalysis.trend);
+    const percentile = roundPercentile(activeAnalysis.percentile);
+    const deltaLabel = formatDelta(activeAnalysis.delta, activeMeta.unit);
+    const beyondWho = childAgeInMonths > 60;
 
     const formatMetricData = (metricKey) => {
         if (!birthDate) return [];
         return (child.growthData || [])
-            .map((d) => {
-                const months = ageInMonths(d.date, child.birthDate);
-                if (months == null || d[metricKey] == null || d[metricKey] === '') return null;
+            .map((record) => {
+                const months = ageInMonths(record.date, child.birthDate);
+                if (months == null || record[metricKey] == null || record[metricKey] === '') return null;
                 return {
                     month: months,
-                    value: Number(d[metricKey]),
-                    date: d.date,
+                    value: Number(record[metricKey]),
+                    date: record.date,
                 };
             })
-            .filter((d) => d && !Number.isNaN(d.month) && !Number.isNaN(d.value) && d.month >= 0)
+            .filter((record) => record && !Number.isNaN(record.month) && !Number.isNaN(record.value) && record.month >= 0)
             .sort((a, b) => a.month - b.month);
     };
 
+    const metricPoints = formatMetricData(activeMetric);
     const historyRows = [...(child.growthData || [])]
         .sort((a, b) => (parseLocalDate(b.date)?.getTime() || 0) - (parseLocalDate(a.date)?.getTime() || 0));
 
     return (
         <div className="growth-chart-page">
-            <nav className="page-nav-final">
-                <button type="button" onClick={() => history.goBack()} className="back-btn">
-                    &rarr; بازگشت
+            <nav className="gc-nav">
+                <button type="button" onClick={() => history.goBack()} className="gc-back">
+                    <FontAwesomeIcon icon={faArrowRight} />
+                    <span>بازگشت</span>
                 </button>
-                <h1 className="page-title">نمودار رشد {childName}</h1>
-                <div className="nav-placeholder"></div>
+                <h1>نمودار رشد</h1>
+                <button type="button" className="gc-nav-add" onClick={openAddModal}>
+                    <FontAwesomeIcon icon={faPlus} />
+                    <span>ثبت</span>
+                </button>
             </nav>
 
-            <div className="page-actions">
+            <header className="gc-hero">
+                <div className="gc-hero-icon" aria-hidden="true">
+                    <FontAwesomeIcon icon={faChild} />
+                </div>
+                <div className="gc-hero-text">
+                    <p className="gc-kicker">منحنی رشد سازمان بهداشت جهانی</p>
+                    <h2>{childName}</h2>
+                    <p className="gc-hero-meta">
+                        {birthDate ? formatAgeLabel(childAgeInMonths) : 'سن نامشخص'}
+                        <span>·</span>
+                        {isBoy ? 'پسر' : 'دختر'}
+                        <span>·</span>
+                        {historyRows.length} اندازه‌گیری
+                    </p>
+                </div>
+            </header>
+
+            <div className="gc-tabs" role="tablist" aria-label="نوع نمودار">
+                {METRIC_TABS.map((tab) => {
+                    const meta = METRIC_META[tab.key];
+                    const analysis = analyses[tab.key];
+                    const active = activeMetric === tab.key;
+                    return (
+                        <button
+                            key={tab.key}
+                            type="button"
+                            role="tab"
+                            aria-selected={active}
+                            className={`gc-tab ${active ? 'is-active' : ''}`}
+                            onClick={() => setActiveMetric(tab.key)}
+                        >
+                            <strong>{meta.label}</strong>
+                            <span>
+                                {analysis.value != null ? `${analysis.value} ${meta.unit}` : 'بدون داده'}
+                            </span>
+                        </button>
+                    );
+                })}
+            </div>
+
+            <section className={`gc-card gc-metric-card ${statusClass(activeAnalysis.status)}`}>
+                <div className="gc-metric-top">
+                    <div>
+                        <p className="gc-metric-label">آخرین {activeMeta.label}</p>
+                        <p className="gc-metric-value">
+                            {activeAnalysis.value != null ? (
+                                <>
+                                    {activeAnalysis.value}
+                                    <span>{activeMeta.unit}</span>
+                                </>
+                            ) : '—'}
+                        </p>
+                    </div>
+                    <div className="gc-metric-badges">
+                        <span className={`gc-status ${statusClass(activeAnalysis.status)}`}>
+                            {activeAnalysis.status}
+                        </span>
+                        {percentile != null && (
+                            <span className="gc-percentile">صدک {percentile}</span>
+                        )}
+                    </div>
+                </div>
+                <div className="gc-metric-facts">
+                    {activeAnalysis.date ? (
+                        <span>تاریخ: {toShamsi(activeAnalysis.date)}</span>
+                    ) : (
+                        <span>هنوز اندازه‌گیری ثبت نشده</span>
+                    )}
+                    {activeAnalysis.ageInMonths != null && (
+                        <span>سن ثبت: {formatAgeLabel(activeAnalysis.ageInMonths)}</span>
+                    )}
+                    <span>روند: {trend.label}</span>
+                    {deltaLabel && <span>تغییر: {deltaLabel}</span>}
+                    <span>{activeAnalysis.count} نقطه روی نمودار</span>
+                </div>
+                <p className="gc-metric-note">{getGrowthInterpretation(activeMetric, activeAnalysis)}</p>
+            </section>
+
+            {beyondWho && (
+                <p className="gc-banner">
+                    منحنی استاندارد سازمان بهداشت جهانی تا ۵ سالگی است. برای سن بالاتر، نقاط روی انتهای نمودار نمایش داده می‌شوند.
+                </p>
+            )}
+
+            <section className="gc-card gc-chart-card">
+                <div className="gc-chart-head">
+                    <h3>
+                        <FontAwesomeIcon icon={faChartLine} />
+                        نمودار {activeMeta.label} به سن
+                    </h3>
+                    <div className="gc-range-toggle">
+                        <button
+                            type="button"
+                            className={rangeMode === 'focus' ? 'is-active' : ''}
+                            onClick={() => setRangeMode('focus')}
+                        >
+                            نمای نزدیک
+                        </button>
+                        <button
+                            type="button"
+                            className={rangeMode === 'full' ? 'is-active' : ''}
+                            onClick={() => setRangeMode('full')}
+                        >
+                            ۰ تا ۵ سال
+                        </button>
+                    </div>
+                </div>
+                <p className="gc-chart-hint">
+                    ناحیه بین صدک ۳ و ۹۷ محدوده طبیعی است. روی نقطه قرمز بزنید تا جزئیات همان اندازه‌گیری دیده شود.
+                </p>
+
+                {metricPoints.length === 0 ? (
+                    <div className="gc-empty">
+                        <p>برای {activeMeta.label} هنوز نقطه‌ای ثبت نشده است.</p>
+                        <button type="button" className="gc-primary-btn" onClick={openAddModal}>
+                            ثبت اولین اندازه‌گیری
+                        </button>
+                    </div>
+                ) : (
+                    <GrowthChart
+                        data={metricPoints}
+                        standardData={standardData}
+                        childName={childName}
+                        yAxisLabel={`${activeMeta.label} (${activeMeta.unit})`}
+                        childAgeInMonths={childAgeInMonths}
+                        rangeMode={rangeMode}
+                        onSelectPoint={setSelectedPoint}
+                        selectedMonth={selectedPoint?.month}
+                    />
+                )}
+
+                {selectedPoint && (
+                    <div className="gc-selected">
+                        <strong>نقطه انتخاب‌شده</strong>
+                        <p>
+                            {selectedPoint.value} {activeMeta.unit}
+                            {selectedPoint.recordDate ? ` · ${toShamsi(selectedPoint.recordDate)}` : ''}
+                            {` · ${formatAgeLabel(selectedPoint.month)}`}
+                        </p>
+                    </div>
+                )}
+
                 <button
                     type="button"
-                    onClick={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        openAddModal();
-                    }}
-                    className="add-data-btn"
+                    className={`gc-accordion ${legendOpen ? 'is-open' : ''}`}
+                    onClick={() => setLegendOpen((open) => !open)}
                 >
-                    + افزودن داده جدید
+                    <span>راهنمای خطوط نمودار</span>
+                    <FontAwesomeIcon icon={faChevronDown} />
                 </button>
-                {birthDate && (
-                    <p className="age-now-label">
-                        سن فعلی کودک: <strong>{formatAgeLabel(childAgeInMonths)}</strong>
-                    </p>
+                {legendOpen && (
+                    <ul className="gc-legend">
+                        {legendItems.map((item) => (
+                            <li key={item.label}>
+                                <i style={{ background: item.color }} />
+                                <div>
+                                    <strong>{item.label}</strong>
+                                    <p>{item.hint}</p>
+                                </div>
+                            </li>
+                        ))}
+                    </ul>
                 )}
-            </div>
+            </section>
 
-            <div className="chart-info-boxes">
-                <MetricInfoCard
-                    title="آخرین قد ثبت‌شده"
-                    analysis={heightAnalysis}
-                    unit="cm"
-                    statusClassName={getStatusClassName(heightAnalysis.status)}
-                />
-                <MetricInfoCard
-                    title="آخرین وزن ثبت‌شده"
-                    analysis={weightAnalysis}
-                    unit="kg"
-                    statusClassName={getStatusClassName(weightAnalysis.status)}
-                />
-                <MetricInfoCard
-                    title="آخرین دور سر ثبت‌شده"
-                    analysis={headAnalysis}
-                    unit="cm"
-                    statusClassName={getStatusClassName(headAnalysis.status)}
-                />
-            </div>
-
-            <div className="history-section">
-                <div className="history-header">
+            <section className="gc-card gc-history-card">
+                <div className="gc-history-head">
                     <h3>تاریخچه اندازه‌گیری‌ها</h3>
                     <span>{historyRows.length} رکورد</span>
                 </div>
                 {historyRows.length === 0 ? (
-                    <p className="history-empty">هنوز اندازه‌گیری ثبت نشده است. از دکمه «افزودن داده جدید» استفاده کنید.</p>
+                    <div className="gc-empty">
+                        <p>هنوز اندازه‌گیری ثبت نشده است.</p>
+                        <button type="button" className="gc-primary-btn" onClick={openAddModal}>
+                            افزودن داده جدید
+                        </button>
+                    </div>
                 ) : (
-                    <div className="history-list">
+                    <div className="gc-history-list">
                         {historyRows.map((record) => {
                             const age = ageInMonths(record.date, child.birthDate);
                             const rowKey = record.id || record.date;
                             const open = expandedId === rowKey;
+                            const metricView = analyzeRecordMetric(activeMetric, child, record);
+                            const rowPercentile = roundPercentile(metricView.percentile);
                             return (
-                                <article key={rowKey} className={`history-item ${open ? 'is-open' : ''}`}>
+                                <article key={rowKey} className={`gc-history-item ${open ? 'is-open' : ''}`}>
                                     <button
                                         type="button"
-                                        className="history-item-main"
+                                        className="gc-history-main"
                                         onClick={() => setExpandedId(open ? null : rowKey)}
                                     >
-                                        <div className="history-item-title">
+                                        <div className="gc-history-title">
                                             <strong>{toShamsi(record.date)}</strong>
                                             <span>{formatAgeLabel(age)}</span>
                                         </div>
-                                        <div className="history-item-summary">
-                                            <span>قد: {record.height != null ? `${record.height} cm` : '—'}</span>
-                                            <span>وزن: {record.weight != null ? `${record.weight} kg` : '—'}</span>
-                                            <span>دور سر: {record.headCircumference != null ? `${record.headCircumference} cm` : '—'}</span>
+                                        <div className="gc-history-summary">
+                                            <span className={activeMetric === 'height' ? 'is-focus' : ''}>
+                                                قد: {record.height != null ? `${record.height} cm` : '—'}
+                                            </span>
+                                            <span className={activeMetric === 'weight' ? 'is-focus' : ''}>
+                                                وزن: {record.weight != null ? `${record.weight} kg` : '—'}
+                                            </span>
+                                            <span className={activeMetric === 'headCircumference' ? 'is-focus' : ''}>
+                                                دور سر: {record.headCircumference != null ? `${record.headCircumference} cm` : '—'}
+                                            </span>
                                         </div>
+                                        {rowPercentile != null && (
+                                            <p className="gc-history-p">
+                                                {activeMeta.label}: صدک {rowPercentile} · {metricView.status}
+                                            </p>
+                                        )}
                                     </button>
                                     {open && (
-                                        <div className="history-item-detail">
-                                            <p>در تاریخ <strong>{toShamsi(record.date)}</strong> (سن {formatAgeLabel(age)}) این مقادیر ثبت شده است:</p>
-                                            <ul>
-                                                <li>قد: {record.height != null ? `${record.height} سانتی‌متر` : 'ثبت نشده'}</li>
-                                                <li>وزن: {record.weight != null ? `${record.weight} کیلوگرم` : 'ثبت نشده'}</li>
-                                                <li>دور سر: {record.headCircumference != null ? `${record.headCircumference} سانتی‌متر` : 'ثبت نشده'}</li>
-                                            </ul>
-                                            <div className="history-item-actions">
-                                                <button type="button" className="btn-edit" onClick={() => openEditModal(record)}>ویرایش</button>
-                                                <button type="button" className="btn-delete" onClick={() => handleDelete(record)}>حذف</button>
+                                        <div className="gc-history-detail">
+                                            <p>
+                                                در تاریخ <strong>{toShamsi(record.date)}</strong> ({formatAgeLabel(age)}) این مقادیر ثبت شده است.
+                                            </p>
+                                            <div className="gc-history-actions">
+                                                <button type="button" className="gc-btn-edit" onClick={() => openEditModal(record)}>
+                                                    <FontAwesomeIcon icon={faPen} /> ویرایش
+                                                </button>
+                                                {confirmDeleteId === rowKey ? (
+                                                    <button type="button" className="gc-btn-delete" onClick={() => handleDelete(record)}>
+                                                        تأیید حذف
+                                                    </button>
+                                                ) : (
+                                                    <button
+                                                        type="button"
+                                                        className="gc-btn-delete"
+                                                        onClick={() => setConfirmDeleteId(rowKey)}
+                                                    >
+                                                        <FontAwesomeIcon icon={faTrash} /> حذف
+                                                    </button>
+                                                )}
                                             </div>
                                         </div>
                                     )}
@@ -490,53 +680,45 @@ const GrowthChartPage = () => {
                         })}
                     </div>
                 )}
-            </div>
+            </section>
 
-            <div className="chart-section">
-                <h3>نمودار قد به سن</h3>
-                <p className="chart-hint">نقاط قرمز بر اساس سن کودک در تاریخ ثبت روی محور ماه قرار می‌گیرند.</p>
-                <GrowthChart
-                    data={formatMetricData('height')}
-                    standardData={isBoy ? whoStats.heightForAgeBoys : whoStats.heightForAgeGirls}
-                    childName={childName}
-                    yAxisLabel="قد (cm)"
-                    childAgeInMonths={childAgeInMonths}
-                />
-            </div>
+            <section className="gc-card">
+                <button
+                    type="button"
+                    className={`gc-accordion ${guideOpen ? 'is-open' : ''}`}
+                    onClick={() => setGuideOpen((open) => !open)}
+                >
+                    <span>
+                        <FontAwesomeIcon icon={faInfoCircle} />
+                        این نمودار چه می‌گوید؟
+                    </span>
+                    <FontAwesomeIcon icon={faChevronDown} />
+                </button>
+                {guideOpen && (
+                    <div className="gc-guide">
+                        <p>نمودار قد، وزن و دور سر را با منحنی استاندارد سازمان بهداشت جهانی (۰ تا ۶۰ ماه) مقایسه می‌کند.</p>
+                        <p>جایگاه بین صدک ۳ و ۹۷ معمولاً در محدوده طبیعی است. تغییر ناگهانی صدک مهم‌تر از یک عدد تکی است.</p>
+                        <p>این صفحه جایگزین معاینه پزشک نیست و برای پیگیری خانگی اندازه‌گیری‌ها طراحی شده است.</p>
+                    </div>
+                )}
+            </section>
 
-            <div className="chart-section">
-                <h3>نمودار وزن به سن</h3>
-                <GrowthChart
-                    data={formatMetricData('weight')}
-                    standardData={isBoy ? whoStats.weightForAgeBoys : whoStats.weightForAgeGirls}
-                    childName={childName}
-                    yAxisLabel="وزن (kg)"
-                    childAgeInMonths={childAgeInMonths}
-                />
-            </div>
-
-            <div className="chart-section">
-                <h3>نمودار دور سر به سن</h3>
-                <GrowthChart
-                    data={formatMetricData('headCircumference')}
-                    standardData={isBoy ? whoStats.headCircumferenceForAgeBoys : whoStats.headCircumferenceForAgeGirls}
-                    childName={childName}
-                    yAxisLabel="دور سر (cm)"
-                    childAgeInMonths={childAgeInMonths}
-                />
-            </div>
+            <button type="button" className="gc-fab" onClick={openAddModal}>
+                <FontAwesomeIcon icon={faPlus} />
+                ثبت اندازه‌گیری
+            </button>
 
             <Modal
                 isOpen={modalIsOpen}
                 onRequestClose={closeModal}
                 contentLabel="Growth Data Modal"
-                className="add-data-modal"
-                overlayClassName="growth-modal-overlay"
+                className="gc-modal"
+                overlayClassName="gc-modal-overlay"
                 shouldCloseOnOverlayClick={!saving}
             >
-                <h2>{editingRecord ? 'ویرایش داده رشد' : 'افزودن داده جدید'}</h2>
-                <div className="add-data-form">
-                    <label className="field-label">تاریخ اندازه‌گیری</label>
+                <h2>{editingRecord ? 'ویرایش داده رشد' : 'ثبت اندازه‌گیری جدید'}</h2>
+                <div className="gc-form">
+                    <label className="gc-field-label" htmlFor="growth-date">تاریخ اندازه‌گیری</label>
                     <DatePicker
                         value={form.date}
                         onChange={(date) => setForm((prev) => ({ ...prev, date }))}
@@ -544,41 +726,56 @@ const GrowthChartPage = () => {
                         locale={persian_fa}
                         format="YYYY/MM/DD"
                         placeholder="تاریخ را انتخاب کنید"
-                        inputClass="form-control"
-                        containerClassName="growth-datepicker"
-                        calendarPosition="bottom-center"
+                        inputClass="gc-input"
+                        containerClassName="gc-datepicker"
+                        calendarPosition="top-center"
                     />
-                    <label className="field-label">قد (cm)</label>
+                    <label className="gc-field-label" htmlFor="growth-height">قد (cm)</label>
                     <input
+                        id="growth-height"
                         type="number"
+                        inputMode="decimal"
                         step="0.1"
+                        min="20"
+                        max="200"
                         value={form.height}
                         onChange={(e) => setForm((prev) => ({ ...prev, height: e.target.value }))}
                         placeholder="مثلاً 72.5"
+                        className="gc-input"
                     />
-                    <label className="field-label">وزن (kg)</label>
+                    <label className="gc-field-label" htmlFor="growth-weight">وزن (kg)</label>
                     <input
+                        id="growth-weight"
                         type="number"
+                        inputMode="decimal"
                         step="0.1"
+                        min="0.5"
+                        max="80"
                         value={form.weight}
                         onChange={(e) => setForm((prev) => ({ ...prev, weight: e.target.value }))}
                         placeholder="مثلاً 9.2"
+                        className="gc-input"
                     />
-                    <label className="field-label">دور سر (cm)</label>
+                    <label className="gc-field-label" htmlFor="growth-head">دور سر (cm)</label>
                     <input
+                        id="growth-head"
                         type="number"
+                        inputMode="decimal"
                         step="0.1"
+                        min="20"
+                        max="70"
                         value={form.headCircumference}
                         onChange={(e) => setForm((prev) => ({ ...prev, headCircumference: e.target.value }))}
                         placeholder="مثلاً 44"
+                        className="gc-input"
                     />
                 </div>
-                {formError && <p className="form-error">{formError}</p>}
-                <div className="modal-actions">
-                    <button type="button" onClick={handleSave} disabled={saving}>
+                {formError && <p className="gc-form-error">{formError}</p>}
+                <div className="gc-modal-actions">
+                    <button type="button" className="gc-primary-btn" onClick={handleSave} disabled={saving}>
                         {saving ? 'در حال ذخیره...' : 'ذخیره'}
                     </button>
-                    <button type="button" onClick={closeModal} disabled={saving}>انصراف</button>
+                    <button type="button" className="gc-ghost-btn" onClick={closeModal} disabled={saving}>انصراف</button>
                 </div>
             </Modal>
         </div>

--- a/client/src/components/GrowthChartPage.js
+++ b/client/src/components/GrowthChartPage.js
@@ -175,12 +175,13 @@ const GrowthChart = ({
                         width={isNarrow ? 38 : 46}
                         tick={{ fontSize: 11, fill: '#5b716e' }}
                         tickMargin={4}
+                        allowDataOverflow={false}
                     />
                     <Tooltip
                         content={<CustomTooltip childName={childName} />}
                         allowEscapeViewBox={{ x: true, y: true }}
                     />
-                    <Area type="monotone" dataKey="P97" stroke="none" fill="#99f6e4" fillOpacity={0.28} connectNulls isAnimationActive={false} />
+                    <Area type="monotone" dataKey="P97" stroke="none" fill="#99f6e4" fillOpacity={0.28} connectNulls isAnimationActive={false} baseValue={yDomain[0]} />
                     <Line type="monotone" dataKey="P3" stroke="#d97706" name="صدک ۳" dot={false} strokeWidth={1.6} connectNulls isAnimationActive={false} />
                     <Line type="monotone" dataKey="P50" stroke="#0f766e" name="صدک ۵۰" dot={false} strokeWidth={2.2} connectNulls isAnimationActive={false} />
                     <Line type="monotone" dataKey="P97" stroke="#0284c7" name="صدک ۹۷" dot={false} strokeWidth={1.6} connectNulls isAnimationActive={false} />

--- a/client/src/utils/growth-analyzer.js
+++ b/client/src/utils/growth-analyzer.js
@@ -40,6 +40,12 @@ const getPercentileForValue = (value, ageMonths, gender, metric) => {
     return 50 + 47 * ((value - standard.P50) / (standard.P97 - standard.P50));
 };
 
+export const METRIC_META = {
+    height: { key: 'height', label: 'قد', unit: 'cm', unitFa: 'سانتی‌متر' },
+    weight: { key: 'weight', label: 'وزن', unit: 'kg', unitFa: 'کیلوگرم' },
+    headCircumference: { key: 'headCircumference', label: 'دور سر', unit: 'cm', unitFa: 'سانتی‌متر' },
+};
+
 export const getAbsoluteStatus = (percentile) => {
     if (percentile === null || percentile === undefined) return 'نامشخص';
     if (percentile < 3) return 'کمبود';
@@ -47,9 +53,71 @@ export const getAbsoluteStatus = (percentile) => {
     return 'نرمال';
 };
 
+export const roundPercentile = (percentile) => {
+    if (percentile == null || Number.isNaN(percentile)) return null;
+    return Math.round(percentile);
+};
+
+export const getTrendMeta = (trend) => {
+    if (trend === 'improving') return { key: 'improving', label: 'صدک رو به افزایش', short: 'افزایشی' };
+    if (trend === 'declining') return { key: 'declining', label: 'صدک رو به کاهش', short: 'کاهشی' };
+    return { key: 'stable', label: 'روند پایدار', short: 'پایدار' };
+};
+
+export const getGrowthInterpretation = (metric, analysis) => {
+    const name = METRIC_META[metric]?.label || 'رشد';
+    if (!analysis || analysis.value == null || analysis.value === '') {
+        return `هنوز ${name} ثبت نشده است. با ثبت اندازه‌گیری، جایگاه کودک روی منحنی رشد مشخص می‌شود.`;
+    }
+
+    const percentile = roundPercentile(analysis.percentile);
+    if (analysis.status === 'کمبود') {
+        return `آخرین ${name} پایین‌تر از صدک ۳ منحنی سازمان بهداشت جهانی است. این به‌تنهایی تشخیص نیست؛ برای تفسیر با پزشک کودک مشورت کنید.`;
+    }
+    if (analysis.status === 'اضافه') {
+        return `آخرین ${name} بالاتر از صدک ۹۷ است. این به‌تنهایی تشخیص نیست؛ برای تفسیر با پزشک کودک مشورت کنید.`;
+    }
+    if (percentile != null) {
+        return `آخرین ${name} حدود صدک ${percentile} است و در محدوده طبیعی منحنی رشد قرار دارد.`;
+    }
+    return `آخرین ${name} ثبت شده است.`;
+};
+
+export const analyzeRecordMetric = (metric, child, record) => {
+    if (!child || !record) {
+        return { value: null, percentile: null, status: 'نامشخص', ageInMonths: null };
+    }
+    const raw = record[metric];
+    const value = raw === undefined || raw === null || raw === '' ? null : Number(raw);
+    const age = ageInMonths(record.date, child.birthDate);
+    if (value == null || Number.isNaN(value)) {
+        return { value: null, percentile: null, status: 'نامشخص', ageInMonths: age };
+    }
+    const percentile = getPercentileForValue(value, age, child.gender, metric);
+    return {
+        value,
+        percentile,
+        status: getAbsoluteStatus(percentile),
+        ageInMonths: age,
+    };
+};
+
 export const analyzeGrowthMetric = (metric, child) => {
+    const empty = {
+        value: null,
+        date: null,
+        ageInMonths: null,
+        percentile: null,
+        status: 'نامشخص',
+        trend: 'stable',
+        previousValue: null,
+        previousDate: null,
+        delta: null,
+        count: 0,
+    };
+
     if (!child || !child.growthData || child.growthData.length === 0) {
-        return { value: null, date: null, ageInMonths: null, status: 'نامشخص', trend: 'stable' };
+        return empty;
     }
 
     const sortedData = [...child.growthData].sort(
@@ -61,18 +129,26 @@ export const analyzeGrowthMetric = (metric, child) => {
     });
 
     if (recordsWithMetric.length === 0) {
-        return { value: null, date: null, ageInMonths: null, status: 'نامشخص', trend: 'stable' };
+        return empty;
     }
 
     const latestRecord = recordsWithMetric[recordsWithMetric.length - 1];
     const latestAge = ageInMonths(latestRecord.date, child.birthDate);
-    const latestP = getPercentileForValue(latestRecord[metric], latestAge, child.gender, metric);
+    const latestValue = Number(latestRecord[metric]);
+    const latestP = getPercentileForValue(latestValue, latestAge, child.gender, metric);
 
     let trend = 'stable';
+    let previousValue = null;
+    let previousDate = null;
+    let delta = null;
+
     if (recordsWithMetric.length >= 2) {
         const previousRecord = recordsWithMetric[recordsWithMetric.length - 2];
         const previousAge = ageInMonths(previousRecord.date, child.birthDate);
-        const previousP = getPercentileForValue(previousRecord[metric], previousAge, child.gender, metric);
+        previousValue = Number(previousRecord[metric]);
+        previousDate = previousRecord.date || null;
+        delta = latestValue - previousValue;
+        const previousP = getPercentileForValue(previousValue, previousAge, child.gender, metric);
         if (latestP !== null && previousP !== null) {
             const diff = latestP - previousP;
             if (Math.abs(diff) > 5) {
@@ -82,11 +158,15 @@ export const analyzeGrowthMetric = (metric, child) => {
     }
 
     return {
-        value: latestRecord[metric],
+        value: latestValue,
         date: latestRecord.date || null,
         ageInMonths: latestAge,
         percentile: latestP,
         status: getAbsoluteStatus(latestP),
         trend,
+        previousValue,
+        previousDate,
+        delta,
+        count: recordsWithMetric.length,
     };
 };

--- a/client/src/utils/growth-chart-helpers.js
+++ b/client/src/utils/growth-chart-helpers.js
@@ -32,6 +32,7 @@ export const getVisibleAgeDomain = ({ childAgeInMonths, points, mode }) => {
         .map((point) => point.month)
         .filter((month) => month != null && !Number.isNaN(month));
     const lastPoint = pointMonths.length ? Math.max(...pointMonths) : 0;
+    const firstPoint = pointMonths.length ? Math.min(...pointMonths) : 0;
     const focusAge = Math.max(age, lastPoint, 0);
 
     if (mode === 'full') {
@@ -39,13 +40,33 @@ export const getVisibleAgeDomain = ({ childAgeInMonths, points, mode }) => {
     }
 
     if (focusAge <= 18) {
-        return [0, Math.min(60, Math.max(12, Math.ceil(focusAge + 6)))];
+        return [0, Math.min(60, Math.max(12, Math.ceil(Math.max(focusAge, lastPoint) + 6)))];
     }
 
-    const start = Math.max(0, Math.floor(focusAge - 12));
-    let end = Math.ceil(focusAge + 6);
+    const start = Math.max(0, Math.floor(Math.min(firstPoint, focusAge) - 1));
+    let end = Math.ceil(Math.max(focusAge, lastPoint) + 6);
     if (end - start < 12) end = start + 12;
     return [start, Math.min(Math.max(end, 12), Math.max(60, Math.ceil(focusAge + 1)))];
+};
+
+export const getYDomain = (visibleRows) => {
+    const whoValues = (visibleRows || [])
+        .flatMap((row) => [row.P3, row.P50, row.P97])
+        .filter((value) => value != null && !Number.isNaN(value));
+    const childValues = (visibleRows || [])
+        .map((row) => row.value)
+        .filter((value) => value != null && !Number.isNaN(value));
+
+    if (!whoValues.length && !childValues.length) return [0, 1];
+
+    const whoMin = whoValues.length ? Math.min(...whoValues) : Math.min(...childValues);
+    const whoMax = whoValues.length ? Math.max(...whoValues) : Math.max(...childValues);
+    const childMin = childValues.length ? Math.min(...childValues) : whoMin;
+    const childMax = childValues.length ? Math.max(...childValues) : whoMax;
+    const whoPad = Math.max((whoMax - whoMin) * 0.08, 1);
+    const minValue = Math.min(whoMin, childMin);
+    const maxValue = Math.max(whoMax, childMax);
+    return [Math.max(0, Math.floor(minValue - whoPad)), Math.ceil(maxValue + whoPad)];
 };
 
 export const buildAgeTicks = (minAge, maxAge) => {

--- a/client/src/utils/growth-chart-helpers.js
+++ b/client/src/utils/growth-chart-helpers.js
@@ -1,0 +1,73 @@
+import { roundAgeMonths } from './growth-dates';
+
+export const buildChartData = (standardData, childPoints) => {
+    const rows = (standardData || []).map((row) => ({
+        month: row.month,
+        P3: row.P3,
+        P50: row.P50,
+        P97: row.P97,
+        value: null,
+        recordDate: null,
+    }));
+
+    (childPoints || []).forEach((point) => {
+        if (point.month == null || point.value == null || Number.isNaN(point.month)) return;
+        const month = roundAgeMonths(Math.max(0, point.month), 2);
+        rows.push({
+            month,
+            P3: null,
+            P50: null,
+            P97: null,
+            value: point.value,
+            recordDate: point.date || null,
+        });
+    });
+
+    return rows.sort((a, b) => a.month - b.month);
+};
+
+export const getVisibleAgeDomain = ({ childAgeInMonths, points, mode }) => {
+    const age = Number(childAgeInMonths) || 0;
+    const pointMonths = (points || [])
+        .map((point) => point.month)
+        .filter((month) => month != null && !Number.isNaN(month));
+    const lastPoint = pointMonths.length ? Math.max(...pointMonths) : 0;
+    const focusAge = Math.max(age, lastPoint, 0);
+
+    if (mode === 'full') {
+        return [0, Math.max(60, Math.ceil(focusAge + 1))];
+    }
+
+    if (focusAge <= 18) {
+        return [0, Math.min(60, Math.max(12, Math.ceil(focusAge + 6)))];
+    }
+
+    const start = Math.max(0, Math.floor(focusAge - 12));
+    let end = Math.ceil(focusAge + 6);
+    if (end - start < 12) end = start + 12;
+    return [start, Math.min(Math.max(end, 12), Math.max(60, Math.ceil(focusAge + 1)))];
+};
+
+export const buildAgeTicks = (minAge, maxAge) => {
+    const span = Math.max(1, maxAge - minAge);
+    const step = span <= 12 ? 2 : span <= 24 ? 3 : span <= 36 ? 6 : 12;
+    const ticks = [];
+    const first = Math.ceil(minAge / step) * step;
+    if (minAge === 0 || first - minAge > step / 2) {
+        ticks.push(Math.round(minAge));
+    }
+    for (let tick = first; tick <= maxAge + 0.001; tick += step) {
+        const rounded = Math.round(tick);
+        if (!ticks.includes(rounded)) ticks.push(rounded);
+    }
+    const last = Math.round(maxAge);
+    if (!ticks.includes(last)) ticks.push(last);
+    return ticks;
+};
+
+export const formatDelta = (delta, unit) => {
+    if (delta == null || Number.isNaN(delta)) return null;
+    const rounded = Math.round(delta * 10) / 10;
+    const sign = rounded > 0 ? '+' : '';
+    return `${sign}${rounded} ${unit}`;
+};

--- a/client/src/utils/growth-chart-helpers.js
+++ b/client/src/utils/growth-chart-helpers.js
@@ -63,10 +63,10 @@ export const getYDomain = (visibleRows) => {
     const whoMax = whoValues.length ? Math.max(...whoValues) : Math.max(...childValues);
     const childMin = childValues.length ? Math.min(...childValues) : whoMin;
     const childMax = childValues.length ? Math.max(...childValues) : whoMax;
-    const whoPad = Math.max((whoMax - whoMin) * 0.08, 1);
     const minValue = Math.min(whoMin, childMin);
     const maxValue = Math.max(whoMax, childMax);
-    return [Math.max(0, Math.floor(minValue - whoPad)), Math.ceil(maxValue + whoPad)];
+    const pad = Math.max((maxValue - minValue) * 0.12, 2);
+    return [Math.max(0, Math.floor(minValue - pad)), Math.ceil(maxValue + pad)];
 };
 
 export const buildAgeTicks = (minAge, maxAge) => {

--- a/client/src/utils/growth-chart-helpers.test.js
+++ b/client/src/utils/growth-chart-helpers.test.js
@@ -1,0 +1,88 @@
+import { buildChartData, getVisibleAgeDomain, buildAgeTicks, formatDelta } from './growth-chart-helpers';
+import { formatAgeLabel } from './growth-dates';
+import { analyzeGrowthMetric, getGrowthInterpretation, getAbsoluteStatus } from './growth-analyzer';
+
+describe('growth chart helpers', () => {
+    test('buildChartData merges WHO rows and child points by age', () => {
+        const rows = buildChartData(
+            [{ month: 0, P3: 46, P50: 50, P97: 54 }],
+            [{ month: 2.4, value: 58, date: '2024-03-01' }]
+        );
+        expect(rows).toHaveLength(2);
+        expect(rows[0].P50).toBe(50);
+        expect(rows[1].value).toBe(58);
+        expect(rows[1].recordDate).toBe('2024-03-01');
+    });
+
+    test('focused domain keeps young infants readable', () => {
+        expect(getVisibleAgeDomain({
+            childAgeInMonths: 4,
+            points: [{ month: 3.5 }],
+            mode: 'focus',
+        })).toEqual([0, 12]);
+    });
+
+    test('focused domain zooms around older toddlers', () => {
+        const [start, end] = getVisibleAgeDomain({
+            childAgeInMonths: 48,
+            points: [{ month: 36 }, { month: 47 }],
+            mode: 'focus',
+        });
+        expect(start).toBeGreaterThanOrEqual(36);
+        expect(end - start).toBeGreaterThanOrEqual(12);
+        expect(end).toBeLessThan(60);
+    });
+
+    test('full domain always includes 0-60', () => {
+        expect(getVisibleAgeDomain({
+            childAgeInMonths: 10,
+            points: [],
+            mode: 'full',
+        })).toEqual([0, 60]);
+    });
+
+    test('buildAgeTicks stays sparse on a long range', () => {
+        const ticks = buildAgeTicks(0, 60);
+        expect(ticks[0]).toBe(0);
+        expect(ticks).toContain(60);
+        expect(ticks.length).toBeLessThanOrEqual(8);
+    });
+
+    test('formatDelta keeps a signed unit label', () => {
+        expect(formatDelta(1.25, 'cm')).toBe('+1.3 cm');
+        expect(formatDelta(-0.4, 'kg')).toBe('-0.4 kg');
+        expect(formatDelta(null, 'cm')).toBeNull();
+    });
+});
+
+describe('growth labels and analysis', () => {
+    test('formatAgeLabel uses years after 12 months', () => {
+        expect(formatAgeLabel(8)).toBe('8 ماهگی');
+        expect(formatAgeLabel(24)).toBe('2 سالگی');
+        expect(formatAgeLabel(30)).toBe('2 سال و 6 ماه');
+    });
+
+    test('analyzeGrowthMetric returns percentile, delta and count', () => {
+        const child = {
+            gender: 'boy',
+            birthDate: '2024-01-01',
+            growthData: [
+                { date: '2024-07-01', height: 67.6 },
+                { date: '2025-01-01', height: 75.7 },
+            ],
+        };
+        const analysis = analyzeGrowthMetric('height', child);
+        expect(analysis.count).toBe(2);
+        expect(analysis.value).toBe(75.7);
+        expect(analysis.delta).toBeCloseTo(8.1);
+        expect(analysis.percentile).toBeGreaterThan(40);
+        expect(analysis.status).toBe('نرمال');
+        expect(getGrowthInterpretation('height', analysis)).toMatch(/صدک/);
+    });
+
+    test('getAbsoluteStatus maps percentile edges', () => {
+        expect(getAbsoluteStatus(2)).toBe('کمبود');
+        expect(getAbsoluteStatus(50)).toBe('نرمال');
+        expect(getAbsoluteStatus(98)).toBe('اضافه');
+    });
+});

--- a/client/src/utils/growth-chart-helpers.test.js
+++ b/client/src/utils/growth-chart-helpers.test.js
@@ -1,4 +1,4 @@
-import { buildChartData, getVisibleAgeDomain, buildAgeTicks, formatDelta } from './growth-chart-helpers';
+import { buildChartData, getVisibleAgeDomain, buildAgeTicks, formatDelta, getYDomain } from './growth-chart-helpers';
 import { formatAgeLabel } from './growth-dates';
 import { analyzeGrowthMetric, getGrowthInterpretation, getAbsoluteStatus } from './growth-analyzer';
 
@@ -22,15 +22,15 @@ describe('growth chart helpers', () => {
         })).toEqual([0, 12]);
     });
 
-    test('focused domain zooms around older toddlers', () => {
+    test('focused domain keeps every recorded point visible', () => {
         const [start, end] = getVisibleAgeDomain({
             childAgeInMonths: 48,
-            points: [{ month: 36 }, { month: 47 }],
+            points: [{ month: 0 }, { month: 24 }, { month: 36 }],
             mode: 'focus',
         });
-        expect(start).toBeGreaterThanOrEqual(36);
-        expect(end - start).toBeGreaterThanOrEqual(12);
-        expect(end).toBeLessThan(60);
+        expect(start).toBe(0);
+        expect(end).toBeGreaterThanOrEqual(36);
+        expect(end).toBeLessThanOrEqual(60);
     });
 
     test('full domain always includes 0-60', () => {
@@ -53,6 +53,15 @@ describe('growth chart helpers', () => {
         expect(formatDelta(-0.4, 'kg')).toBe('-0.4 kg');
         expect(formatDelta(null, 'cm')).toBeNull();
     });
+
+    test('getYDomain includes WHO band and child points', () => {
+        const [min, max] = getYDomain([
+            { P3: 89, P50: 96, P97: 103, value: null },
+            { P3: null, P50: null, P97: null, value: 110 },
+        ]);
+        expect(min).toBeLessThanOrEqual(89);
+        expect(max).toBeGreaterThanOrEqual(110);
+    });
 });
 
 describe('growth labels and analysis', () => {
@@ -60,6 +69,7 @@ describe('growth labels and analysis', () => {
         expect(formatAgeLabel(8)).toBe('8 ماهگی');
         expect(formatAgeLabel(24)).toBe('2 سالگی');
         expect(formatAgeLabel(30)).toBe('2 سال و 6 ماه');
+        expect(formatAgeLabel(48.7)).toBe('4 سال و 1 ماه');
     });
 
     test('analyzeGrowthMetric returns percentile, delta and count', () => {

--- a/client/src/utils/growth-dates.js
+++ b/client/src/utils/growth-dates.js
@@ -75,9 +75,14 @@ export const roundAgeMonths = (months, digits = 1) => {
 export const formatAgeLabel = (months) => {
     const value = roundAgeMonths(months, 1);
     if (value == null) return '—';
-    if (value < 12) return `${value} ماهگی`;
+    if (value < 12) {
+        const whole = Math.round(value);
+        if (Math.abs(value - whole) < 0.2) return `${whole} ماهگی`;
+        return `${value} ماهگی`;
+    }
     const years = Math.floor(value / 12);
-    const rem = roundAgeMonths(value - years * 12, 1);
-    if (rem < 0.3) return `${years} سالگی`;
-    return `${years} سال و ${rem} ماه`;
+    const remRounded = Math.round(value - years * 12);
+    if (remRounded <= 0) return `${years} سالگی`;
+    if (remRounded >= 12) return `${years + 1} سالگی`;
+    return `${years} سال و ${remRounded} ماه`;
 };

--- a/client/src/utils/growth-dates.js
+++ b/client/src/utils/growth-dates.js
@@ -75,5 +75,9 @@ export const roundAgeMonths = (months, digits = 1) => {
 export const formatAgeLabel = (months) => {
     const value = roundAgeMonths(months, 1);
     if (value == null) return '—';
-    return `${value} ماهگی`;
+    if (value < 12) return `${value} ماهگی`;
+    const years = Math.floor(value / 12);
+    const rem = roundAgeMonths(value - years * 12, 1);
+    if (rem < 0.3) return `${years} سالگی`;
+    return `${years} سال و ${rem} ماه`;
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
صفحه نمودار رشد ناقص و سخت‌خوان بود؛ مخصوصاً روی موبایل هر سه نمودار با هم دیده می‌شدند و اطلاعات صدک/روند نمایش داده نمی‌شد.

## تغییرات
- یک نمودار در هر لحظه با تب‌های قد / وزن / دور سر
- نمودار بالاتر از کارت توضیح آمده تا در موبایل بدون اسکرول طولانی دیده شود
- نمای نزدیک همه نقاط ثبت‌شده را نگه می‌دارد (دیگر نقطه اول حذف نمی‌شود)
- کارت آخرین اندازه‌گیری: مقدار، صدک، وضعیت، روند، تغییر نسبت به دفعه قبل و توضیح غیرتشخیصی
- راهنمای رنگی همیشه زیر نمودار + توضیح صدک به‌صورت آکاردئون
- تاریخچه با صدک همان معیار فعال، ویرایش و حذف تأیید دومرحله‌ای
- فرم ثبت به‌صورت bottom sheet روی موبایل + دکمه ثابت ثبت اندازه‌گیری بالای نوار پایین
- برچسب سن خواناتر (سال و ماه)

## تست
- ۱۰ تست واحد برای دامنه نمودار، برچسب سن و تحلیل صدک
- بررسی دستی روی عرض آیفون (۳۹۰×۸۴۴): تب‌ها، هر سه نمودار، فرم ثبت، تاریخچه

[نمودار قد در موبایل](https://cursor.com/agents/bc-9547fb48-7f62-4bce-ad38-9438dd442410/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgrowth_chart_mobile_height.webp)
[نمودار وزن در موبایل](https://cursor.com/agents/bc-9547fb48-7f62-4bce-ad38-9438dd442410/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgrowth_chart_mobile_weight.webp)
[growth_chart_mobile_walkthrough.mp4](https://cursor.com/agents/bc-9547fb48-7f62-4bce-ad38-9438dd442410/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgrowth_chart_mobile_walkthrough.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9547fb48-7f62-4bce-ad38-9438dd442410?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9547fb48-7f62-4bce-ad38-9438dd442410&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

